### PR TITLE
Bump ampel verifier

### DIFF
--- a/ampel/verify/action.yml
+++ b/ampel/verify/action.yml
@@ -48,7 +48,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/ampel@5d8810718bc82f37add5904d92f85f35fa736ab4
+    - uses: carabiner-dev/actions/install/ampel@416592cb4e9b92304f46653bc7964f24aad7186f
       name: 🔴🟡🟢 AMPEL Setup
       id: install
 
@@ -69,7 +69,7 @@ runs:
 
     - if: ${{ inputs.attest == 'true' }}
       name: Setup bnd
-      uses: carabiner-dev/actions/install/bnd@5d8810718bc82f37add5904d92f85f35fa736ab4
+      uses: carabiner-dev/actions/install/bnd@416592cb4e9b92304f46653bc7964f24aad7186f
 
     - if: ${{ inputs.attest == 'true' }}
       name: sign-ampel-results

--- a/beaker/tests/action.yml
+++ b/beaker/tests/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/beaker@HEAD
+    - uses: carabiner-dev/actions/install/beaker@416592cb4e9b92304f46653bc7964f24aad7186f
       name: Beaker Setup
       id: install
 
-    - uses: carabiner-dev/actions/install/bnd@HEAD
+    - uses: carabiner-dev/actions/install/bnd@416592cb4e9b92304f46653bc7964f24aad7186f
       name: bnd Setup
       id: install-bnd
 


### PR DESCRIPTION
This pull request updates the referenced versions of shared GitHub Actions used for setup in both the `ampel/verify/action.yml` and `beaker/tests/action.yml` workflows. The changes ensure that all steps use a consistent and specific commit hash for the `ampel`, `beaker`, and `bnd` installation actions.

Dependency version updates:

* Updated the `ampel` and `bnd` installation steps in `ampel/verify/action.yml` to reference commit `416592cb4e9b92304f46653bc7964f24aad7186f` instead of the previous commit hash. [[1]](diffhunk://#diff-31e56df38636909c37c0bf0d9489103529040c41124dd3fb4f0436577c869942L51-R51) [[2]](diffhunk://#diff-31e56df38636909c37c0bf0d9489103529040c41124dd3fb4f0436577c869942L72-R72)
* Updated the `beaker` and `bnd` installation steps in `beaker/tests/action.yml` to reference commit `416592cb4e9b92304f46653bc7964f24aad7186f` instead of `HEAD`.