### PR TITLE
Go checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ codebase IDs.
 See the [unpack/sbom README](unpack/sbom/README.md) for full documentation,
 filename conventions, and more examples.
 
+### Go Actions
+
+| Action | Description |
+| --- | --- |
+| `go/versions` | Resolves the project, latest stable, and previous supported Go versions |
+| `go/check-latest` | Checks that `go.mod` references the latest stable Go release |
+| `go/check-previous` | Checks that `go.mod` references the previous supported Go release |
+
+See the [go/ README](go/README.md) for full documentation and examples.
+
 ### Available Installers
 
 | Action | Description |

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,133 @@
+# Go Actions
+
+Reusable GitHub Actions for managing Go versions in your projects. These actions
+read your project's `go.mod` and the [Go release API](https://go.dev/dl/?mode=json)
+to verify your project is using a supported Go version.
+
+## go/versions
+
+Resolves Go version information from three sources: the project's `go.mod`, the
+latest stable Go release, and the previous supported Go release. This action is
+used internally by `go/check-latest` and `go/check-previous`.
+
+### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `go-mod-path` | No | `go.mod` | Path to the go.mod file |
+
+### Outputs
+
+| Output | Example | Description |
+| --- | --- | --- |
+| `GO_VERSION_PROJECT` | `1.25.8` | Full Go version from go.mod |
+| `GO_MINOR_VERSION_PROJECT` | `1.25` | Minor version from go.mod (no patch) |
+| `GO_VERSION_STABLE` | `1.26.1` | Latest stable Go release |
+| `GO_MINOR_VERSION_STABLE` | `1.26` | Latest stable minor version (no patch) |
+| `GO_VERSION_PREVIOUS` | `1.25.8` | Previous supported Go release |
+| `GO_MINOR_VERSION_PREVIOUS` | `1.25` | Previous supported minor version (no patch) |
+
+### Usage
+
+```yaml
+- name: Resolve Go versions
+  id: go-versions
+  uses: carabiner-dev/actions/go/versions@main
+
+- name: Set up Go
+  uses: actions/setup-go@v5
+  with:
+    go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
+```
+
+## go/check-latest
+
+Checks that the project's `go.mod` references the latest stable Go release
+(including patch version). Fails with an actionable error message if the version
+doesn't match.
+
+### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `go-mod-path` | No | `go.mod` | Path to the go.mod file |
+
+### Usage
+
+```yaml
+- uses: carabiner-dev/actions/go/check-latest@main
+```
+
+With a custom go.mod path:
+
+```yaml
+- uses: carabiner-dev/actions/go/check-latest@main
+  with:
+    go-mod-path: 'src/go.mod'
+```
+
+On failure, the action produces an error like:
+
+```
+go.mod is using Go 1.25.3 but the latest stable release is Go 1.26.1.
+Please update go.mod to Go 1.26.1.
+```
+
+## go/check-previous
+
+Checks that the project's `go.mod` references the previous supported Go release
+(including patch version). This is useful for projects that intentionally track
+the previous release branch rather than the latest. Fails with an actionable
+error message if the version doesn't match.
+
+### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `go-mod-path` | No | `go.mod` | Path to the go.mod file |
+
+### Usage
+
+```yaml
+- uses: carabiner-dev/actions/go/check-previous@main
+```
+
+On failure, the action produces an error like:
+
+```
+go.mod is using Go 1.24.5 but the previous supported release is Go 1.25.8.
+Please update go.mod to Go 1.25.8.
+```
+
+## Building a Version Matrix
+
+The `go/versions` action is useful for building CI matrices that test against
+both supported Go versions:
+
+```yaml
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      go-versions: ${{ steps.matrix.outputs.go-versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: go-versions
+        uses: carabiner-dev/actions/go/versions@main
+      - id: matrix
+        run: |
+          echo "go-versions=[\"${{ steps.go-versions.outputs.GO_VERSION_STABLE }}\",\"${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}\"]" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: resolve
+    strategy:
+      matrix:
+        go-version: ${{ fromJSON(needs.resolve.outputs.go-versions) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: go test ./...
+```

--- a/go/check-latest/action.yml
+++ b/go/check-latest/action.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: go-check-latest
+author: carabiner-dev
+description: >
+  Checks that a project's go.mod references the latest stable Go release.
+  Fails with an actionable error message if the version is outdated.
+
+inputs:
+  go-mod-path:
+    description: 'Path to go.mod (default: go.mod in the repo root)'
+    required: false
+    default: 'go.mod'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve Go versions
+      id: versions
+      uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
+      with:
+        go-mod-path: ${{ inputs.go-mod-path }}
+
+    - name: Check go.mod uses latest stable Go
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        PROJECT="${{ steps.versions.outputs.GO_VERSION_PROJECT }}"
+        STABLE="${{ steps.versions.outputs.GO_VERSION_STABLE }}"
+
+        echo "Project go.mod version: ${PROJECT}"
+        echo "Latest stable version:  ${STABLE}"
+
+        if [ "$PROJECT" != "$STABLE" ]; then
+          echo "::error::go.mod is using Go ${PROJECT} but the latest stable release is Go ${STABLE}. Please update go.mod to Go ${STABLE}."
+          exit 1
+        fi
+
+        echo "go.mod is up to date with the latest stable Go release (${STABLE})."

--- a/go/check-previous/action.yml
+++ b/go/check-previous/action.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: go-check-previous
+author: carabiner-dev
+description: >
+  Checks that a project's go.mod references the previous supported Go release.
+  Fails with an actionable error message if the version is outdated.
+
+inputs:
+  go-mod-path:
+    description: 'Path to go.mod (default: go.mod in the repo root)'
+    required: false
+    default: 'go.mod'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve Go versions
+      id: versions
+      uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
+      with:
+        go-mod-path: ${{ inputs.go-mod-path }}
+
+    - name: Check go.mod uses previous supported Go
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        PROJECT="${{ steps.versions.outputs.GO_VERSION_PROJECT }}"
+        PREVIOUS="${{ steps.versions.outputs.GO_VERSION_PREVIOUS }}"
+
+        echo "Project go.mod version:       ${PROJECT}"
+        echo "Previous supported version:   ${PREVIOUS}"
+
+        if [ "$PROJECT" != "$PREVIOUS" ]; then
+          echo "::error::go.mod is using Go ${PROJECT} but the previous supported release is Go ${PREVIOUS}. Please update go.mod to Go ${PREVIOUS}."
+          exit 1
+        fi
+
+        echo "go.mod is up to date with the previous supported Go release (${PREVIOUS})."


### PR DESCRIPTION
This pull request introduces a new set of reusable GitHub Actions for managing and verifying Go versions in projects. It adds two new actions—`go/check-latest` and `go/check-previous`—that ensure a project's `go.mod` references either the latest stable or the previous supported Go release, respectively. Comprehensive documentation and usage examples are provided to help teams integrate these actions into their CI pipelines.

**New Go version management actions:**

* Added `go/check-latest` composite action, which checks that the project's `go.mod` references the latest stable Go release and fails with an actionable error if outdated. (`go/check-latest/action.yml`)
* Added `go/check-previous` composite action, which checks that the project's `go.mod` references the previous supported Go release and fails with an actionable error if outdated. (`go/check-previous/action.yml`)

**Documentation updates:**

* Updated `README.md` to summarize the new Go Actions and link to their documentation.
* Added a new `go/README.md` with detailed documentation for `go/versions`, `go/check-latest`, and `go/check-previous`, including inputs, outputs, usage examples, and CI matrix integration strategies.