### PR TITLE
Support uploading SBOMs to relases

### DIFF
--- a/unpack/sbom/README.md
+++ b/unpack/sbom/README.md
@@ -29,7 +29,16 @@ That's it. With no inputs, the action will:
 | `ignore` | No | `""` | Newline-separated list of path patterns to pass to `unpack ls --ignore` when discovering codebases. |
 | `files` | No | `false` | Include file information in the generated SBOMs. |
 | `format` | No | `spdx` | SBOM format: `spdx` or `cyclonedx` (also accepts `cdx`). |
-| `output-path` | No | `.` | Directory where generated SBOMs will be written. |
+| `output-path` | No | `""` | Directory where generated SBOMs will be written. When empty, a temporary directory is created automatically. |
+| `push-to-release` | No | `""` | When set, upload the generated SBOMs to the GitHub release matching this tag (e.g. `v1.2.3`). Requires `GH_TOKEN` to be set in the environment. |
+
+## Permissions
+
+When using `push-to-release`, the token set in `GH_TOKEN` must have `contents: write`
+permission to upload assets to the GitHub release.
+
+If you want to sign the generated SBOMs, the workflow also needs `id-token: write`
+permission to request an OIDC token for signing.
 
 ## Outputs
 
@@ -113,6 +122,20 @@ steps:
       ignore: |
         vendor
         third_party
+```
+
+### Upload SBOMs to a GitHub release
+
+```yaml
+steps:
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
+
+  - uses: carabiner-dev/actions/unpack/sbom@main
+    with:
+      output-path: /tmp
+      push-to-release: ${{ steps.tag.outputs.tag_name }}
+    env:
+      GH_TOKEN: ${{ github.token }}
 ```
 
 ### Upload SBOMs as artifacts

--- a/unpack/sbom/action.yml
+++ b/unpack/sbom/action.yml
@@ -40,9 +40,16 @@ inputs:
   output-path:
     description: >
       Directory where generated SBOMs will be written.
-      Defaults to the current working directory.
+      When empty, a temporary directory is created automatically.
     required: false
-    default: '.'
+    default: ''
+  push-to-release:
+    description: >
+      When set, upload the generated SBOMs to the GitHub release
+      matching this tag (e.g. "v1.2.3"). Requires the GH_TOKEN
+      environment variable to be set.
+    required: false
+    default: ''
 
 outputs:
   files:
@@ -67,3 +74,15 @@ runs:
         INPUT_OUTPUT_PATH: ${{ inputs.output-path }}
       run: |
         ${{ github.action_path }}/generate.sh
+
+    - name: Upload SBOMs to release
+      if: inputs.push-to-release != ''
+      shell: bash
+      env:
+        SBOM_FILES: ${{ steps.generate.outputs.files }}
+        RELEASE_TAG: ${{ inputs.push-to-release }}
+      run: |
+        for f in ${SBOM_FILES}; do
+          echo "Uploading ${f} to release ${RELEASE_TAG}"
+          gh release upload "${RELEASE_TAG}" "${f}"
+        done

--- a/unpack/sbom/generate.sh
+++ b/unpack/sbom/generate.sh
@@ -10,8 +10,13 @@ set -euo pipefail
 # Resolve inputs
 # ---------------------------------------------------------------------------
 FORMAT="${INPUT_FORMAT:-spdx}"
-OUTPUT_PATH="${INPUT_OUTPUT_PATH:-.}"
 FILES_FLAG="${INPUT_FILES:-false}"
+
+if [[ -n "${INPUT_OUTPUT_PATH:-}" ]]; then
+  OUTPUT_PATH="${INPUT_OUTPUT_PATH}"
+else
+  OUTPUT_PATH="$(mktemp -d)"
+fi
 
 case "${FORMAT}" in
   spdx)            EXTRACT_FMT="spdx"     ; EXT="spdx.json" ;;


### PR DESCRIPTION
This pull request enhances the `unpack/sbom` GitHub Action by adding support for uploading generated SBOMs directly to a GitHub release, and improves the flexibility of output path handling. It also updates documentation to reflect these new features and requirements.

**New feature: SBOM upload to GitHub release**
- Added a new input `push-to-release` to `action.yml` that, when set, uploads generated SBOMs to the GitHub release matching the specified tag using the `gh release upload` command. This requires the `GH_TOKEN` environment variable to be set. [[1]](diffhunk://#diff-e5e544c465124a3e8a0dfb13197b522fe5d289867632850a7f2be765ecd4a9b5L43-R52) [[2]](diffhunk://#diff-e5e544c465124a3e8a0dfb13197b522fe5d289867632850a7f2be765ecd4a9b5R77-R88)
- Updated the documentation (`README.md`) with usage instructions and permission requirements for uploading SBOMs to a release. [[1]](diffhunk://#diff-83834fcbcfb4e803e66c0db338ac4fe52d219de1475fe097597ca8ef024a89f8L32-R41) [[2]](diffhunk://#diff-83834fcbcfb4e803e66c0db338ac4fe52d219de1475fe097597ca8ef024a89f8R127-R140)

**Output path handling improvements**
- Changed the default behavior for the `output-path` input: if left empty, a temporary directory is created automatically for SBOM output, rather than defaulting to the current directory. This is reflected in both the action logic (`generate.sh`) and documentation. [[1]](diffhunk://#diff-e5e544c465124a3e8a0dfb13197b522fe5d289867632850a7f2be765ecd4a9b5L43-R52) [[2]](diffhunk://#diff-a15ad1df2751ce6f163cd52f7b908f9fe064eda8f1eca34d204d035e1b7ef9d2L13-R20) [[3]](diffhunk://#diff-83834fcbcfb4e803e66c0db338ac4fe52d219de1475fe097597ca8ef024a89f8L32-R41)

**Documentation updates**
- Expanded the `README.md` to describe the new `push-to-release` input, its required permissions, and provided example workflow steps for uploading SBOMs to a release. [[1]](diffhunk://#diff-83834fcbcfb4e803e66c0db338ac4fe52d219de1475fe097597ca8ef024a89f8L32-R41) [[2]](diffhunk://#diff-83834fcbcfb4e803e66c0db338ac4fe52d219de1475fe097597ca8ef024a89f8R127-R140)