### PR TITLE
Use yq to find binary versions

### DIFF
--- a/.github/workflows/check-binary-versions.yaml
+++ b/.github/workflows/check-binary-versions.yaml
@@ -54,7 +54,7 @@ jobs:
           fi
 
           # Get current default version from the action file
-          CURRENT=$(grep -A2 "^  version:" "$ACTION_FILE" | grep "default:" | sed "s/.*default: *['\"]\\(.*\\)['\"].*/\\1/")
+          CURRENT=$(yq '.inputs.version.default' "$ACTION_FILE")
           if [ -z "$CURRENT" ]; then
             echo "::notice::No version default found in ${ACTION_FILE}, skipping"
             exit 0


### PR DESCRIPTION
This pull request updates the way the current default version is extracted from the action file in the `.github/workflows/check-binary-versions.yaml` workflow. The change replaces a `grep`/`sed` pipeline with `yq` for more reliable YAML parsing.

**Workflow reliability improvement:**

* Updated the method for extracting the default version from the action file by switching from a `grep`/`sed` pipeline to `yq`, ensuring more accurate and robust YAML parsing in the workflow (`.github/workflows/check-binary-versions.yaml`).