### PR TITLE
Update ampel installer to v1.1.4

### DIFF
--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -3,7 +3,7 @@
 
 name: setup ampel
 author: carabiner-dev
-description: 'Installs the 🔴🟡🟢 AMPEL policy engine into to the runner environment'
+description: "Installs the \U0001F534\U0001F7E1\U0001F7E2 AMPEL policy engine into to the runner environment"
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -15,73 +15,70 @@ inputs:
   version:
     description: 'AMPEL Version to Install'
     required: false
-    default: 'v1.1.2'
+    default: 'v1.1.4'
 runs:
   using: "composite"
   steps:
-      # - name: Checkout code
-      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      #   with:
-      #     persist-credentials: false
-      #     repository: carabiner-dev/ampel
-      #     path: '.build/ampel/'
-      #     ref: main
+    # - name: Checkout code
+    #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    #   with:
+    #     persist-credentials: false
+    #     repository: carabiner-dev/ampel
+    #     path: '.build/ampel/'
+    #     ref: main
 
-      # - name: Set up Go
-      #   uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      #   with:
-      #     go-version: '1.24'
-      #     cache: false
-      #     check-latest: true
+    # - name: Set up Go
+    #   uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+    #   with:
+    #     go-version: '1.24'
+    #     cache: false
+    #     check-latest: true
 
-      # - name: Build
-      #   shell: bash
-      #   run: |
-      #     mkdir -p ${{ inputs.install-dir }}/bin || :
-      #     cd .build/ampel && go build -o ${{ inputs.install-dir }}/bin/ampel ./cmd/ampel/
-      #     cd - 
-      #     rm -rf .build/ampel
-      - name: Detect platform
-        id: platform
-        shell: bash
-        run: |
-          OS="${{ runner.os }}"
-          ARCH="${{ runner.arch }}"
+    # - name: Build
+    #   shell: bash
+    #   run: |
+    #     mkdir -p ${{ inputs.install-dir }}/bin || :
+    #     cd .build/ampel && go build -o ${{ inputs.install-dir }}/bin/ampel ./cmd/ampel/
+    #     cd - 
+    #     rm -rf .build/ampel
+    - name: Detect platform
+      id: platform
+      shell: bash
+      run: |
+        OS="${{ runner.os }}"
+        ARCH="${{ runner.arch }}"
 
-          case "$OS" in
-            Linux)  os="linux" ;;
-            macOS)  os="darwin" ;;
-            Windows) os="windows" ;;
-            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-          esac
+        case "$OS" in
+          Linux)  os="linux" ;;
+          macOS)  os="darwin" ;;
+          Windows) os="windows" ;;
+          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
+        esac
 
-          case "$ARCH" in
-            X64)   arch="amd64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-          esac
+        case "$ARCH" in
+          X64)   arch="amd64" ;;
+          ARM64) arch="arm64" ;;
+          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
 
-          ext=""
-          if [ "$os" = "windows" ]; then
-            ext=".exe"
-          fi
+        ext=""
+        if [ "$os" = "windows" ]; then
+          ext=".exe"
+        fi
 
-          echo "filename=ampel-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-          echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-
-      - name: Install ampel
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/ampel/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-          chmod 0755 ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }}
-
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-        shell: bash
-      - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - shell: bash
-        run: ampel version
+        echo "filename=ampel-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
+        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
+    - name: Install ampel
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.install-dir }}/bin || :
+        curl -Lo ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/ampel/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
+        chmod 0755 ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }}
+    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+      shell: bash
+    - if: ${{ runner.os == 'Windows' }}
+      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      shell: pwsh
+    - shell: bash
+      run: ampel version


### PR DESCRIPTION
Bumps the default version of the ampel installer from v1.1.2 to v1.1.4. Latest release: https://github.com/carabiner-dev/ampel/releases/tag/v1.1.4