### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ its attestations against a policy.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@v1.1.2
+- uses: carabiner-dev/actions/ampel/verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     policy: 'path/to/policy.yaml'   # URI or path to policy code
     subject: 'path/to/artifact'     # or digest, eg sha256:98349875bf3e09...
@@ -45,7 +45,7 @@ its attestations against a policy.
 **Basic verification:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@v1.1.2
+- uses: carabiner-dev/actions/ampel/verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/binary'
@@ -55,7 +55,7 @@ its attestations against a policy.
 **Verification with custom attestations:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@v1.1.2
+- uses: carabiner-dev/actions/ampel/verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     policy: '.ampel/policy.yaml'
     subject: 'sha256:abc123...'
@@ -67,7 +67,7 @@ its attestations against a policy.
 **Verification with attestation push:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@v1.1.2
+- uses: carabiner-dev/actions/ampel/verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -80,7 +80,7 @@ its attestations against a policy.
 **Verification without failing the workflow:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@v1.1.2
+- uses: carabiner-dev/actions/ampel/verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -98,7 +98,7 @@ codebase IDs.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@main
+- uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     ecosystems: |
       golang

--- a/go/README.md
+++ b/go/README.md
@@ -32,10 +32,10 @@ used internally by `go/check-latest` and `go/check-previous`.
 ```yaml
 - name: Resolve Go versions
   id: go-versions
-  uses: carabiner-dev/actions/go/versions@main
+  uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 
 - name: Set up Go
-  uses: actions/setup-go@v5
+  uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
   with:
     go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
 ```
@@ -55,13 +55,13 @@ doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@main
+- uses: carabiner-dev/actions/go/check-latest@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 ```
 
 With a custom go.mod path:
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@main
+- uses: carabiner-dev/actions/go/check-latest@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     go-mod-path: 'src/go.mod'
 ```
@@ -89,7 +89,7 @@ error message if the version doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-previous@main
+- uses: carabiner-dev/actions/go/check-previous@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 ```
 
 On failure, the action produces an error like:
@@ -111,9 +111,9 @@ jobs:
     outputs:
       go-versions: ${{ steps.matrix.outputs.go-versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: go-versions
-        uses: carabiner-dev/actions/go/versions@main
+        uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
       - id: matrix
         run: |
           echo "go-versions=[\"${{ steps.go-versions.outputs.GO_VERSION_STABLE }}\",\"${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}\"]" >> "$GITHUB_OUTPUT"
@@ -125,8 +125,8 @@ jobs:
         go-version: ${{ fromJSON(needs.resolve.outputs.go-versions) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test ./...

--- a/unpack/sbom/README.md
+++ b/unpack/sbom/README.md
@@ -10,7 +10,7 @@ format.
 ## Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@main
+- uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 ```
 
 That's it. With no inputs, the action will:
@@ -72,16 +72,16 @@ When the CycloneDX format is used, the extension is `.cdx.json` instead of `.spd
 
 ```yaml
 steps:
-  - uses: actions/checkout@v4
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 ```
 
 ### Generate only for Go and npm ecosystems
 
 ```yaml
 steps:
-  - uses: actions/checkout@v4
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     with:
       ecosystems: |
         golang
@@ -93,7 +93,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     with:
       codebases: |
         golang:.
@@ -105,7 +105,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     with:
       format: cyclonedx
       files: 'true'
@@ -117,7 +117,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     with:
       ignore: |
         vendor
@@ -130,7 +130,7 @@ steps:
 steps:
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
 
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     with:
       output-path: /tmp
       push-to-release: ${{ steps.tag.outputs.tag_name }}
@@ -144,12 +144,12 @@ steps:
 steps:
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.
 
-  - uses: carabiner-dev/actions/unpack/sbom@main
+  - uses: carabiner-dev/actions/unpack/sbom@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
     id: sbom
     with:
       output-path: sboms/
 
-  - uses: actions/upload-artifact@v4
+  - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: sboms
       path: sboms/


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v6.0.2` | `de0fac2e4500` |
| `actions/setup-go` | `v6.4.0` | `4a3601121dd0` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.1.6` | `360ffa1eb909` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>