### PR TITLE
Add gomodtidy action

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -99,6 +99,42 @@ go.mod is using Go 1.24.5 but the previous supported release is Go 1.25.8.
 Please update go.mod to Go 1.25.8.
 ```
 
+## go/modtidy
+
+Runs `go mod tidy` and fails if `go.mod` or `go.sum` would change. Useful as a
+CI check to ensure committed module files stay in sync with the source. Assumes
+Go is already installed on the runner (e.g. via `actions/setup-go`).
+
+### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working-directory` | No | `.` | Directory in which to run `go mod tidy` |
+
+### Usage
+
+```yaml
+- uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+  with:
+    go-version-file: 'go.mod'
+
+- uses: carabiner-dev/actions/go/modtidy@main
+```
+
+With a custom working directory:
+
+```yaml
+- uses: carabiner-dev/actions/go/modtidy@main
+  with:
+    working-directory: 'src'
+```
+
+On failure, the action prints the diff and an error like:
+
+```
+go.mod or go.sum is not tidy. Run 'go mod tidy' locally and commit the result.
+```
+
 ## Building a Version Matrix
 
 The `go/versions` action is useful for building CI matrices that test against

--- a/go/modtidy/action.yml
+++ b/go/modtidy/action.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: go-modtidy
+author: carabiner-dev
+description: >
+  Runs `go mod tidy` and fails if go.mod or go.sum would change.
+  Assumes Go is already installed on the runner.
+
+inputs:
+  working-directory:
+    description: 'Directory in which to run go mod tidy (default: repo root)'
+    required: false
+    default: '.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run go mod tidy and check for diff
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v go >/dev/null 2>&1; then
+          echo "::error::go is not installed on this runner. Set up Go before calling this action (e.g. actions/setup-go)."
+          exit 1
+        fi
+
+        for f in go.mod go.sum; do
+          if [ ! -f "$f" ]; then
+            echo "::error::$f not found in $(pwd)"
+            exit 1
+          fi
+        done
+
+        go mod tidy
+
+        if ! git diff --exit-code -- go.mod go.sum; then
+          echo "::error::go.mod or go.sum is not tidy. Run 'go mod tidy' locally and commit the result."
+          exit 1
+        fi
+
+        echo "go.mod and go.sum are tidy."


### PR DESCRIPTION
This pull request introduces a new GitHub Action, `go/modtidy`, to help ensure that Go module files (`go.mod` and `go.sum`) remain tidy and consistent with the source code. It includes documentation and an implementation of the action, which is designed to be used in CI workflows to catch uncommitted changes after running `go mod tidy`.

**New GitHub Action for Go module file consistency:**

* Added a new composite action `go/modtidy` that runs `go mod tidy` and fails if `go.mod` or `go.sum` would change, ensuring module files are always in sync with the source. The action checks for the presence of Go and the necessary files, and outputs helpful error messages if requirements are not met. (`go/modtidy/action.yml`)
* Updated the documentation in `go/README.md` to describe the usage, inputs, and example workflow integration for the new `go/modtidy` action. (`go/README.md`)