### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -118,13 +118,13 @@ Go is already installed on the runner (e.g. via `actions/setup-go`).
   with:
     go-version-file: 'go.mod'
 
-- uses: carabiner-dev/actions/go/modtidy@main
+- uses: carabiner-dev/actions/go/modtidy@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
 ```
 
 With a custom working directory:
 
 ```yaml
-- uses: carabiner-dev/actions/go/modtidy@main
+- uses: carabiner-dev/actions/go/modtidy@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
   with:
     working-directory: 'src'
 ```


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v6.0.2` | `de0fac2e4500` |
| `actions/setup-go` | `v6.4.0` | `4a3601121dd0` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.1.6` | `360ffa1eb909` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>