### PR TITLE
Add policyctl isntaller

### DIFF
--- a/install/policyctl/action.yml
+++ b/install/policyctl/action.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: setup policyctl
+author: carabiner-dev
+description: 'Installs the Carabiner policyctl AMPEL policy manager to the runner environment'
+branding:
+  icon: 'download-cloud'
+  color: 'green'
+inputs:
+  install-dir:
+    description: 'Path to install the binary'
+    required: false
+    default: '$HOME/.carabiner'
+  version:
+    description: 'policyctl version to install'
+    required: false
+    default: 'v0.1.0'
+runs:
+  using: "composite"
+  steps:
+      - name: Detect platform
+        id: platform
+        shell: bash
+        run: |
+          OS="${{ runner.os }}"
+          ARCH="${{ runner.arch }}"
+
+          case "$OS" in
+            Linux)  os="linux" ;;
+            macOS)  os="darwin" ;;
+            Windows) os="windows" ;;
+            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
+          esac
+
+          case "$ARCH" in
+            X64)   arch="amd64" ;;
+            ARM64) arch="arm64" ;;
+            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
+          esac
+
+          ext=""
+          if [ "$os" = "windows" ]; then
+            ext=".exe"
+          fi
+
+          echo "filename=policyctl-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
+          echo "ext=${ext}" >> "$GITHUB_OUTPUT"
+
+      - name: Install policyctl
+        shell: bash
+        run: |
+          mkdir -p ${{ inputs.install-dir }}/bin || :
+          curl -Lo ${{ inputs.install-dir }}/bin/policyctl${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/policyctl/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
+          chmod 0755 ${{ inputs.install-dir }}/bin/policyctl${{ steps.platform.outputs.ext }}
+
+      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+        shell: bash
+      - if: ${{ runner.os == 'Windows' }}
+        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      - shell: bash
+        run: policyctl version


### PR DESCRIPTION
This pull request introduces a new GitHub Action for installing the Carabiner `policyctl` AMPEL policy manager tool in CI runner environments. The action automatically detects the runner's OS and architecture, downloads the correct binary, and adds it to the system path.

Key additions:

**New GitHub Action for Policy Manager Installation:**

* Added `install/policyctl/action.yml`, which defines a composite GitHub Action to install the `policyctl` binary for Linux, macOS, and Windows environments. The action handles platform detection, download, installation, and path configuration, and verifies the installation by running `policyctl version`.