### PR TITLE
Migrate installers to D&V action

### DIFF
--- a/.github/workflows/test-installers.yaml
+++ b/.github/workflows/test-installers.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
-        tool: [ampel-bootstrap, ampel, bnd, beaker, revex, snappy, unpack]
+        tool: [ampel-bootstrap, ampel, bnd, beaker, revex, snappy, unpack, policyctl]
         exclude:
           # beaker has no Windows binary
           - runner: windows-latest
@@ -39,6 +39,8 @@ jobs:
         uses: ./install/snappy
       - if: matrix.tool == 'unpack'
         uses: ./install/unpack
+      - if: matrix.tool == 'policyctl'
+        uses: ./install/policyctl
 
       - if: matrix.tool == 'ampel-bootstrap'
         name: Verify bootstrap binary runs

--- a/.github/workflows/test-installers.yaml
+++ b/.github/workflows/test-installers.yaml
@@ -50,6 +50,28 @@ jobs:
         shell: bash
         run: ${{ matrix.tool }} --help
 
+  test-download-and-verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download and verify snappy
+        uses: ./install/download-and-verify
+        with:
+          tool: snappy
+          version: v0.2.4
+          attestation-file: snappy-v0.2.4.provenance.json
+
+      - name: Verify snappy is on PATH
+        shell: bash
+        run: snappy version
+
   test-ampel-verify:
     runs-on: ubuntu-latest
     permissions:

--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 
 name: setup ampel
@@ -19,66 +19,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - name: Checkout code
-    #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    #   with:
-    #     persist-credentials: false
-    #     repository: carabiner-dev/ampel
-    #     path: '.build/ampel/'
-    #     ref: main
-
-    # - name: Set up Go
-    #   uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-    #   with:
-    #     go-version: '1.24'
-    #     cache: false
-    #     check-latest: true
-
-    # - name: Build
-    #   shell: bash
-    #   run: |
-    #     mkdir -p ${{ inputs.install-dir }}/bin || :
-    #     cd .build/ampel && go build -o ${{ inputs.install-dir }}/bin/ampel ./cmd/ampel/
-    #     cd - 
-    #     rm -rf .build/ampel
-    - name: Detect platform
-      id: platform
-      shell: bash
-      run: |
-        OS="${{ runner.os }}"
-        ARCH="${{ runner.arch }}"
-
-        case "$OS" in
-          Linux)  os="linux" ;;
-          macOS)  os="darwin" ;;
-          Windows) os="windows" ;;
-          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-        esac
-
-        case "$ARCH" in
-          X64)   arch="amd64" ;;
-          ARM64) arch="arm64" ;;
-          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-        esac
-
-        ext=""
-        if [ "$os" = "windows" ]; then
-          ext=".exe"
-        fi
-
-        echo "filename=ampel-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-    - name: Install ampel
-      shell: bash
-      run: |
-        mkdir -p ${{ inputs.install-dir }}/bin || :
-        curl -Lo ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/ampel/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-        chmod 0755 ${{ inputs.install-dir }}/bin/ampel${{ steps.platform.outputs.ext }}
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-      shell: bash
-    - if: ${{ runner.os == 'Windows' }}
-      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh
-    - shell: bash
-      run: ampel version
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: ampel
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: ampel-${{ inputs.version }}.provenance.json

--- a/install/beaker/action.yml
+++ b/install/beaker/action.yml
@@ -1,13 +1,9 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
-
-# [!] Build notice:
-# Note that this installer curls the beaker linux binary. This
-# will replaced with a verified installer soon.
 
 name: setup beaker
 author: carabiner-dev
-description: 'Installs the Carabiner beaker attester into to the runner environment'
+description: 'Installs the Carabiner beaker test attester into the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -19,43 +15,17 @@ inputs:
   version:
     description: 'beaker version to install'
     required: false
-    default: 'v0.1.1'
+    default: 'v0.1.2'
 runs:
   using: "composite"
   steps:
-      - name: Detect platform
-        id: platform
-        shell: bash
-        run: |
-          OS="${{ runner.os }}"
-          ARCH="${{ runner.arch }}"
-
-          case "$OS" in
-            Linux)  os="linux" ;;
-            macOS)  os="darwin" ;;
-            Windows) echo "::error::beaker does not have a Windows binary"; exit 1 ;;
-            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-          esac
-
-          case "$ARCH" in
-            X64)   arch="amd64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-          esac
-
-          echo "filename=beaker-${{ inputs.version }}-${os}-${arch}" >> "$GITHUB_OUTPUT"
-
-      - name: Install beaker
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/beaker https://github.com/carabiner-dev/beaker/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-          chmod 0755 ${{ inputs.install-dir }}/bin/beaker
-
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - shell: bash
-        run: beaker version
-  
+    - if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        echo "::error::beaker does not have a Windows binary"
+        exit 1
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: beaker
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}

--- a/install/bnd/action.yml
+++ b/install/bnd/action.yml
@@ -1,13 +1,9 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
-
-# [!] Build notice:
-# Note that this installer downloads bnd fromthe release page. This
-# will replaced with a verified installer soon.
 
 name: setup bnd
 author: carabiner-dev
-description: 'Installs the Carabiner bnd attester into to the runner environment'
+description: 'Installs the Carabiner bnd attester into the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -23,44 +19,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Detect platform
-      id: platform
-      shell: bash
-      run: |
-        OS="${{ runner.os }}"
-        ARCH="${{ runner.arch }}"
-
-        case "$OS" in
-          Linux)  os="linux" ;;
-          macOS)  os="darwin" ;;
-          Windows) os="windows" ;;
-          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-        esac
-
-        case "$ARCH" in
-          X64)   arch="amd64" ;;
-          ARM64) arch="arm64" ;;
-          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-        esac
-
-        ext=""
-        if [ "$os" = "windows" ]; then
-          ext=".exe"
-        fi
-
-        echo "filename=bnd-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-    - name: Install bnd
-      shell: bash
-      run: |
-        mkdir -p ${{ inputs.install-dir }}/bin || :
-        curl -Lo ${{ inputs.install-dir }}/bin/bnd${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/bnd/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-        chmod 0755 ${{ inputs.install-dir }}/bin/bnd${{ steps.platform.outputs.ext }}
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-      shell: bash
-    - if: ${{ runner.os == 'Windows' }}
-      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh
-    - shell: bash
-      run: bnd version
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: bnd
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -32,12 +32,35 @@ inputs:
     description: 'Name of the attestation file in the release'
     required: false
     default: 'attestations.jsonl'
+  policy:
+    description: >
+      Ampel policy locator (VCS locator or path) used by `ampel verify`.
+      Defaults to a pinned revision of the carabiner-dev policies repo's
+      slsa-build-point policy.
+    required: false
+    default: 'git+https://github.com/carabiner-dev/policies@eed2d09ac2a7f8f5238a24b30492e378d8d77ad3#slsa/slsa-build-point.json'
+  context:
+    description: >
+      Newline-separated context values passed to `ampel verify` as `-x KEY:VALUE`.
+      When empty, the action injects `buildPoint:git+ssh://github.com/carabiner-dev/<repo>`
+      derived from the download location, matching the URI scheme used in the
+      `resolvedDependencies` of carabiner-dev SLSA provenances.
+    required: false
+    default: ''
+  signers:
+    description: >
+      Newline-separated signer identity specs passed to `ampel verify` as `--signer SPEC`.
+      When empty, the action injects a sigstore regexp spec pinned to the
+      `<repo>/.github/workflows/release.yaml` workflow under carabiner-dev,
+      with the tag left as a regex wildcard.
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
       - name: Bootstrap trusted ampel
         if: inputs.verify == 'true'
-        uses: carabiner-dev/actions/install/ampel-bootstrap@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
+        uses: carabiner-dev/actions/install/ampel-bootstrap@0a075bb75a68646d05f99c85cbbf2be40dd8e442 # bootstrap rotated to ampel v1.2.1
         id: bootstrap
 
       - name: Detect platform
@@ -85,12 +108,38 @@ runs:
       - name: Verify ${{ inputs.tool }} binary
         if: inputs.verify == 'true'
         shell: bash
+        env:
+          CONTEXT_INPUT: ${{ inputs.context }}
+          SIGNERS_INPUT: ${{ inputs.signers }}
+          DEFAULT_BUILD_POINT: git+ssh://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}
+          DEFAULT_SIGNER: 'sigstore(regexp)::https://token\.actions\.githubusercontent\.com::https://github\.com/carabiner-dev/${{ steps.platform.outputs.repo }}/\.github/workflows/release\.yaml@refs/tags/[^/]+'
         run: |
           echo "::group::Verify ${{ inputs.tool }} ${{ inputs.version }}"
-          ${{ steps.bootstrap.outputs.ampel-path }} verify \
-            --subject="${{ inputs.install-dir }}/bin/${{ inputs.tool }}${{ steps.platform.outputs.ext }}" \
-            --collector="https://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}/releases/download/${{ inputs.version }}/${{ inputs.attestation-file }}" \
-            --policy="git+https://github.com/carabiner-dev/policies#slsa/slsa-build-point.json"
+
+          args=(verify)
+          args+=(--subject="${{ inputs.install-dir }}/bin/${{ inputs.tool }}${{ steps.platform.outputs.ext }}")
+          args+=(--collector="https://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}/releases/download/${{ inputs.version }}/${{ inputs.attestation-file }}")
+          args+=(--policy="${{ inputs.policy }}")
+
+          if [ -n "$CONTEXT_INPUT" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              args+=(-x "$line")
+            done <<< "$CONTEXT_INPUT"
+          else
+            args+=(-x "buildPoint:$DEFAULT_BUILD_POINT")
+          fi
+
+          if [ -n "$SIGNERS_INPUT" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              args+=(--signer "$line")
+            done <<< "$SIGNERS_INPUT"
+          else
+            args+=(--signer "$DEFAULT_SIGNER")
+          fi
+
+          "${{ steps.bootstrap.outputs.ampel-path }}" "${args[@]}"
           echo "::endgroup::"
 
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}

--- a/install/policyctl/action.yml
+++ b/install/policyctl/action.yml
@@ -19,47 +19,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Detect platform
-        id: platform
-        shell: bash
-        run: |
-          OS="${{ runner.os }}"
-          ARCH="${{ runner.arch }}"
-
-          case "$OS" in
-            Linux)  os="linux" ;;
-            macOS)  os="darwin" ;;
-            Windows) os="windows" ;;
-            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-          esac
-
-          case "$ARCH" in
-            X64)   arch="amd64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-          esac
-
-          ext=""
-          if [ "$os" = "windows" ]; then
-            ext=".exe"
-          fi
-
-          echo "filename=policyctl-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-          echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-
-      - name: Install policyctl
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/policyctl${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/policyctl/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-          chmod 0755 ${{ inputs.install-dir }}/bin/policyctl${{ steps.platform.outputs.ext }}
-
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-        shell: bash
-      - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - shell: bash
-        run: policyctl version
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: policyctl
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: policyctl-${{ inputs.version }}.provenance.json

--- a/install/revex/action.yml
+++ b/install/revex/action.yml
@@ -1,9 +1,5 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
-
-# [!] Build notice:
-# Note that this installer downloads and builds vexflow at head. This
-# will replaced with a verified installer soon.
 
 name: setup revex
 author: carabiner-dev
@@ -19,73 +15,12 @@ inputs:
   version:
     description: 'revex version to install'
     required: false
-    default: 'v0.0.1'
+    default: 'v0.0.2'
 runs:
   using: "composite"
   steps:
-      # - name: Checkout code
-      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      #   with:
-      #     persist-credentials: false
-      #     repository: carabiner-dev/revex
-      #     path: '.build/revex/'
-      #     ref: main
-
-      # - name: Set up Go
-      #   uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      #   with:
-      #     go-version-file: '.build/revex/go.mod'
-      #     cache: false
-      #     check-latest: true
-
-      # - name: Build
-      #   shell: bash
-      #   run: |
-      #     mkdir -p ${{ inputs.install-dir }}/bin || :
-      #     cd .build/revex && go build -o ${{ inputs.install-dir }}/bin/revex .
-      #     cd - 
-      #     rm -rf .build/revex
-      - name: Detect platform
-        id: platform
-        shell: bash
-        run: |
-          OS="${{ runner.os }}"
-          ARCH="${{ runner.arch }}"
-
-          case "$OS" in
-            Linux)  os="linux" ;;
-            macOS)  os="darwin" ;;
-            Windows) os="windows" ;;
-            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-          esac
-
-          case "$ARCH" in
-            X64)   arch="amd64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-          esac
-
-          ext=""
-          if [ "$os" = "windows" ]; then
-            ext=".exe"
-          fi
-
-          echo "filename=revex-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-          echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-
-      - name: Install revex
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/revex${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/revex/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-          chmod 0755 ${{ inputs.install-dir }}/bin/revex${{ steps.platform.outputs.ext }}
-
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-        shell: bash
-      - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - shell: bash
-        run: revex --help
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: revex
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -1,13 +1,9 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-# [!] Build notice:
-# Note that this installer curls the snappy linux binary. This
-# will replaced with a verified installer soon.
-
-name: setup bnd
+name: setup snappy
 author: carabiner-dev
-description: 'Installs the Carabiner snappy util into to the runner environment'
+description: 'Installs the Carabiner snappy API snapshotter into the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -19,48 +15,13 @@ inputs:
   version:
     description: 'snappy version to install'
     required: false
-    default: 'v0.2.3'
+    default: 'v0.2.4'
 runs:
   using: "composite"
   steps:
-    - name: Detect platform
-      id: platform
-      shell: bash
-      run: |
-        OS="${{ runner.os }}"
-        ARCH="${{ runner.arch }}"
-
-        case "$OS" in
-          Linux)  os="linux" ;;
-          macOS)  os="darwin" ;;
-          Windows) os="windows" ;;
-          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-        esac
-
-        case "$ARCH" in
-          X64)   arch="amd64" ;;
-          ARM64) arch="arm64" ;;
-          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-        esac
-
-        ext=""
-        if [ "$os" = "windows" ]; then
-          ext=".exe"
-        fi
-
-        echo "filename=snappy-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-    - name: Install snappy
-      shell: bash
-      run: |
-        mkdir -p ${{ inputs.install-dir }}/bin || :
-        curl -Lo ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/snappy/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-        chmod 0755 ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }}
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-      shell: bash
-    - if: ${{ runner.os == 'Windows' }}
-      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh
-    - shell: bash
-      run: snappy version
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: snappy
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: snappy-${{ inputs.version }}.provenance.json

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-name: setup snappy
+# [!] Build notice:
+# Note that this installer curls the snappy linux binary. This
+# will replaced with a verified installer soon.
+
+name: setup bnd
 author: carabiner-dev
-description: 'Installs the Carabiner snappy API snapshotter into the runner environment'
+description: 'Installs the Carabiner snappy util into to the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -19,9 +23,44 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
-      with:
-        tool: snappy
-        version: ${{ inputs.version }}
-        install-dir: ${{ inputs.install-dir }}
-        attestation-file: snappy-${{ inputs.version }}.provenance.json
+    - name: Detect platform
+      id: platform
+      shell: bash
+      run: |
+        OS="${{ runner.os }}"
+        ARCH="${{ runner.arch }}"
+
+        case "$OS" in
+          Linux)  os="linux" ;;
+          macOS)  os="darwin" ;;
+          Windows) os="windows" ;;
+          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
+        esac
+
+        case "$ARCH" in
+          X64)   arch="amd64" ;;
+          ARM64) arch="arm64" ;;
+          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+
+        ext=""
+        if [ "$os" = "windows" ]; then
+          ext=".exe"
+        fi
+
+        echo "filename=snappy-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
+        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
+    - name: Install snappy
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.install-dir }}/bin || :
+        curl -Lo ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/snappy/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
+        chmod 0755 ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }}
+    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+      shell: bash
+    - if: ${{ runner.os == 'Windows' }}
+      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      shell: pwsh
+    - shell: bash
+      run: snappy version

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -1,13 +1,9 @@
-# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-# [!] Build notice:
-# Note that this installer curls the snappy linux binary. This
-# will replaced with a verified installer soon.
-
-name: setup bnd
+name: setup snappy
 author: carabiner-dev
-description: 'Installs the Carabiner snappy util into to the runner environment'
+description: 'Installs the Carabiner snappy API snapshotter into the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -23,44 +19,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Detect platform
-      id: platform
-      shell: bash
-      run: |
-        OS="${{ runner.os }}"
-        ARCH="${{ runner.arch }}"
-
-        case "$OS" in
-          Linux)  os="linux" ;;
-          macOS)  os="darwin" ;;
-          Windows) os="windows" ;;
-          *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-        esac
-
-        case "$ARCH" in
-          X64)   arch="amd64" ;;
-          ARM64) arch="arm64" ;;
-          *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-        esac
-
-        ext=""
-        if [ "$os" = "windows" ]; then
-          ext=".exe"
-        fi
-
-        echo "filename=snappy-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-        echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-    - name: Install snappy
-      shell: bash
-      run: |
-        mkdir -p ${{ inputs.install-dir }}/bin || :
-        curl -Lo ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/snappy/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-        chmod 0755 ${{ inputs.install-dir }}/bin/snappy${{ steps.platform.outputs.ext }}
-    - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-      run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-      shell: bash
-    - if: ${{ runner.os == 'Windows' }}
-      run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh
-    - shell: bash
-      run: snappy version
+    - uses: carabiner-dev/actions/install/download-and-verify@360ffa1eb909b0105d4eccb6d6ef337911c34952 # v1.1.6
+      with:
+        tool: snappy
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: snappy-${{ inputs.version }}.provenance.json

--- a/install/unpack/action.yml
+++ b/install/unpack/action.yml
@@ -15,51 +15,13 @@ inputs:
   version:
     description: 'Unpack version to install'
     required: false
-    default: 'v0.1.0'
+    default: 'v0.2.1'
 runs:
   using: "composite"
   steps:
-      - name: Detect platform
-        id: platform
-        shell: bash
-        run: |
-          OS="${{ runner.os }}"
-          ARCH="${{ runner.arch }}"
-
-          case "$OS" in
-            Linux)  os="linux" ;;
-            macOS)  os="darwin" ;;
-            Windows) os="windows" ;;
-            *) echo "::error::Unsupported OS: $OS"; exit 1 ;;
-          esac
-
-          case "$ARCH" in
-            X64)   arch="amd64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
-          esac
-
-          ext=""
-          if [ "$os" = "windows" ]; then
-            ext=".exe"
-          fi
-
-          echo "filename=unpack-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
-          echo "ext=${ext}" >> "$GITHUB_OUTPUT"
-
-      - name: Install unpack
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/unpack${{ steps.platform.outputs.ext }} https://github.com/carabiner-dev/unpack/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}
-          chmod 0755 ${{ inputs.install-dir }}/bin/unpack${{ steps.platform.outputs.ext }}
-
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
-        shell: bash
-      - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      - shell: bash
-        run: unpack version
+    - uses: carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
+      with:
+        tool: unpack
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: unpack-${{ inputs.version }}.provenance.json


### PR DESCRIPTION
This pull request refactors all installer GitHub Actions for Carabiner tools to use a single, centralized `download-and-verify` action, improving maintainability and consistency of binary verification. It also introduces new configuration options for policy, context, and signers, and adds support for the `policyctl` tool in the test workflow. Several tool versions are updated as well.

Key changes include:

**Installer Refactoring and Verification Pipeline:**

* All tool installer actions (`ampel`, `beaker`, `bnd`, `revex`, `snappy`, `policyctl`) now delegate installation and verification to the shared `download-and-verify` action, replacing custom platform-detection and download logic with a unified, provenance-verified approach. This ensures consistent security and reduces code duplication. [[1]](diffhunk://#diff-aae9aed90f4ae8fed725248d50e623cddeb4263fd5cee6de824e2eb4c207339cL22-R27) [[2]](diffhunk://#diff-448cb2637f7183be7207acf442728f479bf8b49941fd0be47e2479086ae93591L22-R31) [[3]](diffhunk://#diff-5d07c7393bda00d4991c856a418381ba36cea0f4dc9ff1a14a07facf28ee64bdL26-R26) [[4]](diffhunk://#diff-179349cf5ec0f44987a118435c10aa89d9e696fa96afd5c5c359fdd60e4aa691L22-R26) [[5]](diffhunk://#diff-f1358eb1366db979b5f856b1ee3ec39580154869287c2a81bacb55993c87b977L22-R27) [[6]](diffhunk://#diff-9f6433605a0ca2bdd16be5d56f98fd05e3fbb5fbc35e485821800318b7a416feL22-R27)

* The `download-and-verify` action now supports new inputs for specifying the verification policy, context, and signers, with sensible defaults that enhance provenance validation and flexibility for downstream workflows. [[1]](diffhunk://#diff-0a72e336c6334619c7f95ed800fec95f9a3e69e665c62da1b4d770a1615ae4deR35-R63) [[2]](diffhunk://#diff-0a72e336c6334619c7f95ed800fec95f9a3e69e665c62da1b4d770a1615ae4deR111-R142)

**Workflow and Tooling Updates:**

* The test workflow (`test-installers.yaml`) is updated to include `policyctl` in the matrix and adds a new job to test downloading and verifying the `snappy` tool, further exercising the new verification logic. [[1]](diffhunk://#diff-bb033c5aeb1f276720b6a45bbdec6fc50b421bcb533083f23fae281a7cc68895L16-R16) [[2]](diffhunk://#diff-bb033c5aeb1f276720b6a45bbdec6fc50b421bcb533083f23fae281a7cc68895R42-R43) [[3]](diffhunk://#diff-bb033c5aeb1f276720b6a45bbdec6fc50b421bcb533083f23fae281a7cc68895R55-R76)

* Tool versions are updated for `beaker` (to `v0.1.2`), `revex` (to `v0.0.2`), and `snappy` (to `v0.2.4`), ensuring the workflow tests current releases. [[1]](diffhunk://#diff-448cb2637f7183be7207acf442728f479bf8b49941fd0be47e2479086ae93591L22-R31) [[2]](diffhunk://#diff-179349cf5ec0f44987a118435c10aa89d9e696fa96afd5c5c359fdd60e4aa691L22-R26) [[3]](diffhunk://#diff-f1358eb1366db979b5f856b1ee3ec39580154869287c2a81bacb55993c87b977L22-R27)

**Other Improvements:**

* Copyright years in installer action metadata are updated.
* Descriptions in action metadata are clarified for several tools. [[1]](diffhunk://#diff-aae9aed90f4ae8fed725248d50e623cddeb4263fd5cee6de824e2eb4c207339cL1-R1) [[2]](diffhunk://#diff-448cb2637f7183be7207acf442728f479bf8b49941fd0be47e2479086ae93591L1-R6) [[3]](diffhunk://#diff-5d07c7393bda00d4991c856a418381ba36cea0f4dc9ff1a14a07facf28ee64bdL1-R6) [[4]](diffhunk://#diff-179349cf5ec0f44987a118435c10aa89d9e696fa96afd5c5c359fdd60e4aa691L1-L7) [[5]](diffhunk://#diff-f1358eb1366db979b5f856b1ee3ec39580154869287c2a81bacb55993c87b977L1-R6)

These changes collectively improve the security, maintainability, and clarity of the installer workflows for all Carabiner CLI tools.



Closes https://github.com/carabiner-dev/actions/issues/51
Supersedes https://github.com/carabiner-dev/actions/issues/49
