### PR TITLE
Resolve zizmor warnings within actions (and add zizmor scanning)

### DIFF
--- a/.github/workflows/test-installers.yaml
+++ b/.github/workflows/test-installers.yaml
@@ -45,7 +45,9 @@ jobs:
       - if: matrix.tool == 'ampel-bootstrap'
         name: Verify bootstrap binary runs
         shell: bash
-        run: ${{ steps.bootstrap.outputs.ampel-path }} version
+        run: ${STEPS_BOOTSTRAP_OUTPUTS_AMPEL_PATH} version
+        env:
+          STEPS_BOOTSTRAP_OUTPUTS_AMPEL_PATH: ${{ steps.bootstrap.outputs.ampel-path }}
 
       - if: matrix.tool != 'ampel-bootstrap'
         name: Verify binary runs

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+# Static analysis of this repo's workflows and composite actions with zizmor,
+# to catch GitHub Actions template injection (and related issues) before merge.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/_demo/scorecard/action.yml
+++ b/_demo/scorecard/action.yml
@@ -37,17 +37,23 @@ runs:
       - name: Build
         shell: bash
         run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          cd .build/scorecard && go build -o ${{ inputs.install-dir }}/bin/scorecard .
+          mkdir -p ${INPUTS_INSTALL_DIR}/bin || :
+          cd .build/scorecard && go build -o ${INPUTS_INSTALL_DIR}/bin/scorecard .
           cd - 
           rm -rf .build/scorecard
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
 
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
         shell: bash
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: bash
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       
       - shell: bash
         run: scorecard version

--- a/ampel/verify/action.yml
+++ b/ampel/verify/action.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Optional --key/--context flags are built as bash arrays for safe quoting.
 name: 'Verify Policy'
 author: "carabiner-dev"
 description: 'Verifies a subject against a policy'
@@ -67,50 +68,65 @@ runs:
     - id: attest-check
       shell: bash
       run: |
-        ATTEST="${{ inputs.attest }}"
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+        ATTEST="${INPUTS_ATTEST}"
+        if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
           echo "::notice::Attestation disabled: no token available for workflow_dispatch events"
           ATTEST="false"
         fi
         echo "attest=${ATTEST}" >> "$GITHUB_OUTPUT"
+      env:
+        INPUTS_ATTEST: ${{ inputs.attest }}
 
     - id: verify
       shell: bash
       run: |
-        KEY_FLAGS=""
-        CONTEXT_FLAGS=""
+        key_flags=()
+        ctx_flags=()
 
-        if [ -n "${{ inputs.context }}" ]; then
-          CONTEXT_FLAGS="--context \"${{ inputs.context }}\""
+        if [ -n "${INPUTS_CONTEXT}" ]; then
+          ctx_flags=(--context "${INPUTS_CONTEXT}")
         fi
 
-        if [ -n "${{ inputs.key }}" ]; then
-          KEY_FLAGS="--key=${{ inputs.key }}"
+        if [ -n "${INPUTS_KEY}" ]; then
+          key_flags+=(--key="${INPUTS_KEY}")
         fi
 
-        if [ -n "${{ inputs.keydata }}" ]; then
+        if [ -n "${INPUTS_KEYDATA}" ]; then
           KEYDATA_FILE=$(mktemp)
-          printf '%s\n' '${{ inputs.keydata }}' > "${KEYDATA_FILE}"
-          KEY_FLAGS="${KEY_FLAGS} --key=${KEYDATA_FILE}"
+          printf '%s\n' "${INPUTS_KEYDATA}" > "${KEYDATA_FILE}"
+          key_flags+=(--key="${KEYDATA_FILE}")
         fi
 
         ampel verify \
-          --subject="${{ inputs.subject }}" \
-          --collector="${{ inputs.collector }}" \
-          --policy="${{ inputs.policy }}" \
-          --exit-code="${{ inputs.fail }}" \
-          --attest-results="${{ steps.attest-check.outputs.attest }}" \
-          --attest-format="${{ inputs.attest-format }}" \
-          --results-path="${{ inputs.results-path }}" \
-          --attestation="${{ inputs.attestation }}" \
-          --signer="${{ inputs.signer }}" \
-          ${KEY_FLAGS} \
-          ${CONTEXT_FLAGS} \
-          --format="html" >> $GITHUB_STEP_SUMMARY
+          --subject="${INPUTS_SUBJECT}" \
+          --collector="${INPUTS_COLLECTOR}" \
+          --policy="${INPUTS_POLICY}" \
+          --exit-code="${INPUTS_FAIL}" \
+          --attest-results="${STEPS_ATTEST_CHECK_OUTPUTS_ATTEST}" \
+          --attest-format="${INPUTS_ATTEST_FORMAT}" \
+          --results-path="${INPUTS_RESULTS_PATH}" \
+          --attestation="${INPUTS_ATTESTATION}" \
+          --signer="${INPUTS_SIGNER}" \
+          "${key_flags[@]}" \
+          "${ctx_flags[@]}" \
+          --format="html" >> "$GITHUB_STEP_SUMMARY"
 
         if [ -n "${KEYDATA_FILE:-}" ]; then
           rm -f "${KEYDATA_FILE}"
         fi
+      env:
+        INPUTS_CONTEXT: ${{ inputs.context }}
+        INPUTS_KEY: ${{ inputs.key }}
+        INPUTS_KEYDATA: ${{ inputs.keydata }}
+        INPUTS_SUBJECT: ${{ inputs.subject }}
+        INPUTS_COLLECTOR: ${{ inputs.collector }}
+        INPUTS_POLICY: ${{ inputs.policy }}
+        INPUTS_FAIL: ${{ inputs.fail }}
+        STEPS_ATTEST_CHECK_OUTPUTS_ATTEST: ${{ steps.attest-check.outputs.attest }}
+        INPUTS_ATTEST_FORMAT: ${{ inputs.attest-format }}
+        INPUTS_RESULTS_PATH: ${{ inputs.results-path }}
+        INPUTS_ATTESTATION: ${{ inputs.attestation }}
+        INPUTS_SIGNER: ${{ inputs.signer }}
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' }}
       name: Setup bnd
@@ -120,8 +136,10 @@ runs:
       name: sign-ampel-results
       shell: bash
       run: |
-        mv ${{ inputs.results-path }} ${{ inputs.results-path }}.tmp
-        bnd statement ${{ inputs.results-path }}.tmp >> ${{ inputs.results-path }}
+        mv "${INPUTS_RESULTS_PATH}" "${INPUTS_RESULTS_PATH}.tmp"
+        bnd statement "${INPUTS_RESULTS_PATH}.tmp" >> "${INPUTS_RESULTS_PATH}"
+      env:
+        INPUTS_RESULTS_PATH: ${{ inputs.results-path }}
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' && inputs.push-attestation == 'true' }}
       name: Push attestation to artifacts

--- a/beaker/tests/action.yml
+++ b/beaker/tests/action.yml
@@ -37,18 +37,25 @@ runs:
       shell: bash
       run: |
         beaker run \
-          --dir="${{ inputs.dir }}" \
-          --output="${{ inputs.output }}.tmp"
+          --dir="${INPUTS_DIR}" \
+          --output="${INPUTS_OUTPUT}.tmp"
+      env:
+        INPUTS_DIR: ${{ inputs.dir }}
+        INPUTS_OUTPUT: ${{ inputs.output }}
 
     - if: ${{ inputs.sign == 'true' }}
       id: "sign-attestation"
       shell: bash
       run: |
-        bnd statement --out="${{ inputs.output }}" "${{ inputs.output }}.tmp"
-        rm "${{ inputs.output }}.tmp"
+        bnd statement --out="${INPUTS_OUTPUT}" "${INPUTS_OUTPUT}.tmp"
+        rm "${INPUTS_OUTPUT}.tmp"
+      env:
+        INPUTS_OUTPUT: ${{ inputs.output }}
 
     - if: ${{ inputs.sign != 'true' }}
       id: "set-attestation-name"
       shell: bash
       run: |
-        mv "${{ inputs.output }}.tmp" "${{ inputs.output }}"
+        mv "${INPUTS_OUTPUT}.tmp" "${INPUTS_OUTPUT}"
+      env:
+        INPUTS_OUTPUT: ${{ inputs.output }}

--- a/bnd/sign/action.yml
+++ b/bnd/sign/action.yml
@@ -49,33 +49,44 @@ runs:
       if: ${{ inputs.is-predicate == 'true' }}
       shell: bash
       run: |
-        if [ -z "${{ inputs.subject }}" ]; then
+        if [ -z "${INPUTS_SUBJECT}" ]; then
           echo "::error::subject is required when is-predicate is true"
           exit 1
         fi
-        if [ -z "${{ inputs.predicate-type }}" ]; then
+        if [ -z "${INPUTS_PREDICATE_TYPE}" ]; then
           echo "::error::predicate-type is required when is-predicate is true"
           exit 1
         fi
+      env:
+        INPUTS_SUBJECT: ${{ inputs.subject }}
+        INPUTS_PREDICATE_TYPE: ${{ inputs.predicate-type }}
 
     - name: Sign statement
       if: ${{ inputs.is-predicate != 'true' }}
       shell: bash
       run: |
-        ATTESTATION=$(bnd statement "${{ inputs.json-path }}")
-        if [ -f "${{ inputs.output }}" ]; then
-          echo "$ATTESTATION" >> "${{ inputs.output }}"
+        ATTESTATION=$(bnd statement "${INPUTS_JSON_PATH}")
+        if [ -f "${INPUTS_OUTPUT}" ]; then
+          echo "$ATTESTATION" >> "${INPUTS_OUTPUT}"
         else
-          echo "$ATTESTATION" > "${{ inputs.output }}"
+          echo "$ATTESTATION" > "${INPUTS_OUTPUT}"
         fi
+      env:
+        INPUTS_JSON_PATH: ${{ inputs.json-path }}
+        INPUTS_OUTPUT: ${{ inputs.output }}
 
     - name: Sign predicate
       if: ${{ inputs.is-predicate == 'true' }}
       shell: bash
       run: |
-        ATTESTATION=$(bnd predicate --subject="${{ inputs.subject }}" --type="${{ inputs.predicate-type }}" "${{ inputs.json-path }}")
-        if [ -f "${{ inputs.output }}" ]; then
-          echo "$ATTESTATION" >> "${{ inputs.output }}"
+        ATTESTATION=$(bnd predicate --subject="${INPUTS_SUBJECT}" --type="${INPUTS_PREDICATE_TYPE}" "${INPUTS_JSON_PATH}")
+        if [ -f "${INPUTS_OUTPUT}" ]; then
+          echo "$ATTESTATION" >> "${INPUTS_OUTPUT}"
         else
-          echo "$ATTESTATION" > "${{ inputs.output }}"
+          echo "$ATTESTATION" > "${INPUTS_OUTPUT}"
         fi
+      env:
+        INPUTS_SUBJECT: ${{ inputs.subject }}
+        INPUTS_PREDICATE_TYPE: ${{ inputs.predicate-type }}
+        INPUTS_JSON_PATH: ${{ inputs.json-path }}
+        INPUTS_OUTPUT: ${{ inputs.output }}

--- a/go/check-latest/action.yml
+++ b/go/check-latest/action.yml
@@ -27,8 +27,8 @@ runs:
       run: |
         set -euo pipefail
 
-        PROJECT="${{ steps.versions.outputs.GO_VERSION_PROJECT }}"
-        STABLE="${{ steps.versions.outputs.GO_VERSION_STABLE }}"
+        PROJECT="${STEPS_VERSIONS_OUTPUTS_GO_VERSION_PROJECT}"
+        STABLE="${STEPS_VERSIONS_OUTPUTS_GO_VERSION_STABLE}"
 
         echo "Project go.mod version: ${PROJECT}"
         echo "Latest stable version:  ${STABLE}"
@@ -39,3 +39,6 @@ runs:
         fi
 
         echo "go.mod is up to date with the latest stable Go release (${STABLE})."
+      env:
+        STEPS_VERSIONS_OUTPUTS_GO_VERSION_PROJECT: ${{ steps.versions.outputs.GO_VERSION_PROJECT }}
+        STEPS_VERSIONS_OUTPUTS_GO_VERSION_STABLE: ${{ steps.versions.outputs.GO_VERSION_STABLE }}

--- a/go/check-previous/action.yml
+++ b/go/check-previous/action.yml
@@ -27,8 +27,8 @@ runs:
       run: |
         set -euo pipefail
 
-        PROJECT="${{ steps.versions.outputs.GO_VERSION_PROJECT }}"
-        PREVIOUS="${{ steps.versions.outputs.GO_VERSION_PREVIOUS }}"
+        PROJECT="${STEPS_VERSIONS_OUTPUTS_GO_VERSION_PROJECT}"
+        PREVIOUS="${STEPS_VERSIONS_OUTPUTS_GO_VERSION_PREVIOUS}"
 
         echo "Project go.mod version:       ${PROJECT}"
         echo "Previous supported version:   ${PREVIOUS}"
@@ -39,3 +39,6 @@ runs:
         fi
 
         echo "go.mod is up to date with the previous supported Go release (${PREVIOUS})."
+      env:
+        STEPS_VERSIONS_OUTPUTS_GO_VERSION_PROJECT: ${{ steps.versions.outputs.GO_VERSION_PROJECT }}
+        STEPS_VERSIONS_OUTPUTS_GO_VERSION_PREVIOUS: ${{ steps.versions.outputs.GO_VERSION_PREVIOUS }}

--- a/go/versions/action.yml
+++ b/go/versions/action.yml
@@ -43,7 +43,7 @@ runs:
         set -euo pipefail
 
         # --- Project version from go.mod ---
-        GOMOD="${{ inputs.go-mod-path }}"
+        GOMOD="${INPUTS_GO_MOD_PATH}"
         if [ ! -f "$GOMOD" ]; then
           echo "::error::go.mod not found at $GOMOD"
           exit 1
@@ -109,3 +109,5 @@ runs:
         echo "Go version (project):  ${GO_VERSION_PROJECT} (minor: ${GO_MINOR_VERSION_PROJECT})"
         echo "Go version (stable):   ${GO_VERSION_STABLE} (minor: ${GO_MINOR_VERSION_STABLE})"
         echo "Go version (previous): ${GO_VERSION_PREVIOUS} (minor: ${GO_MINOR_VERSION_PREVIOUS})"
+      env:
+        INPUTS_GO_MOD_PATH: ${{ inputs.go-mod-path }}

--- a/install/ampel-bootstrap/action.yml
+++ b/install/ampel-bootstrap/action.yml
@@ -59,10 +59,10 @@ runs:
       run: |
         BOOTSTRAP_VERSION="v1.2.1"
         BOOTSTRAP_DIR=$(mktemp -d)
-        BINARY="${BOOTSTRAP_DIR}/ampel${{ steps.platform.outputs.ext }}"
+        BINARY="${BOOTSTRAP_DIR}/ampel${STEPS_PLATFORM_OUTPUTS_EXT}"
 
         # Download the pinned bootstrap version with retries for transient errors
-        DOWNLOAD_URL="https://github.com/carabiner-dev/ampel/releases/download/${BOOTSTRAP_VERSION}/${{ steps.platform.outputs.filename }}"
+        DOWNLOAD_URL="https://github.com/carabiner-dev/ampel/releases/download/${BOOTSTRAP_VERSION}/${STEPS_PLATFORM_OUTPUTS_FILENAME}"
         MAX_RETRIES=3
         for attempt in $(seq 1 "${MAX_RETRIES}"); do
           if curl -sSfL -o "${BINARY}" "${DOWNLOAD_URL}"; then
@@ -80,7 +80,7 @@ runs:
         # Verify SHA-256 against hardcoded hashes.
         # These hashes are the trust root. They MUST be updated when rotating
         # the bootstrap version.
-        case "${{ steps.platform.outputs.filename }}" in
+        case "${STEPS_PLATFORM_OUTPUTS_FILENAME}" in
           ampel-v1.2.1-darwin-arm64)
             EXPECTED="469339770fd059c655fa2205d11ea6658314bf43417a6b28b4e95229ce56e082" ;;
           ampel-v1.2.1-linux-amd64)
@@ -90,7 +90,7 @@ runs:
           ampel-v1.2.1-windows-amd64.exe)
             EXPECTED="f4c94dfb49339b169af8faa9f176bb28fa7ce61c5ae8fa2a40ec67904d8d151a" ;;
           *)
-            echo "::error::No hardcoded hash for platform: ${{ steps.platform.outputs.filename }}"
+            echo "::error::No hardcoded hash for platform: ${STEPS_PLATFORM_OUTPUTS_FILENAME}"
             exit 1 ;;
         esac
 
@@ -111,3 +111,6 @@ runs:
         chmod 0755 "${BINARY}"
         echo "ampel-path=${BINARY}" >> "$GITHUB_OUTPUT"
         echo "Bootstrap ampel ${BOOTSTRAP_VERSION} verified successfully (sha256: ${ACTUAL})"
+      env:
+        STEPS_PLATFORM_OUTPUTS_EXT: ${{ steps.platform.outputs.ext }}
+        STEPS_PLATFORM_OUTPUTS_FILENAME: ${{ steps.platform.outputs.filename }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -88,22 +88,33 @@ runs:
             ext=".exe"
           fi
 
-          REPO="${{ inputs.repo }}"
+          REPO="${INPUTS_REPO}"
           if [ -z "$REPO" ]; then
-            REPO="${{ inputs.tool }}"
+            REPO="${INPUTS_TOOL}"
           fi
 
-          echo "filename=${{ inputs.tool }}-${{ inputs.version }}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
+          echo "filename=${INPUTS_TOOL}-${INPUTS_VERSION}-${os}-${arch}${ext}" >> "$GITHUB_OUTPUT"
           echo "ext=${ext}" >> "$GITHUB_OUTPUT"
           echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_REPO: ${{ inputs.repo }}
+          INPUTS_TOOL: ${{ inputs.tool }}
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Install ${{ inputs.tool }}
         shell: bash
         run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -sSfL -o ${{ inputs.install-dir }}/bin/${{ inputs.tool }}${{ steps.platform.outputs.ext }} \
-            "https://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}/releases/download/${{ inputs.version }}/${{ steps.platform.outputs.filename }}"
-          chmod 0755 ${{ inputs.install-dir }}/bin/${{ inputs.tool }}${{ steps.platform.outputs.ext }}
+          mkdir -p ${INPUTS_INSTALL_DIR}/bin || :
+          curl -sSfL -o ${INPUTS_INSTALL_DIR}/bin/${INPUTS_TOOL}${STEPS_PLATFORM_OUTPUTS_EXT} \
+            "https://github.com/carabiner-dev/${STEPS_PLATFORM_OUTPUTS_REPO}/releases/download/${INPUTS_VERSION}/${STEPS_PLATFORM_OUTPUTS_FILENAME}"
+          chmod 0755 ${INPUTS_INSTALL_DIR}/bin/${INPUTS_TOOL}${STEPS_PLATFORM_OUTPUTS_EXT}
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
+          INPUTS_TOOL: ${{ inputs.tool }}
+          STEPS_PLATFORM_OUTPUTS_EXT: ${{ steps.platform.outputs.ext }}
+          STEPS_PLATFORM_OUTPUTS_REPO: ${{ steps.platform.outputs.repo }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          STEPS_PLATFORM_OUTPUTS_FILENAME: ${{ steps.platform.outputs.filename }}
 
       - name: Verify ${{ inputs.tool }} binary
         if: inputs.verify == 'true'
@@ -113,13 +124,21 @@ runs:
           SIGNERS_INPUT: ${{ inputs.signers }}
           DEFAULT_BUILD_POINT: git+ssh://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}
           DEFAULT_SIGNER: 'sigstore(regexp)::https://token\.actions\.githubusercontent\.com::https://github\.com/carabiner-dev/${{ steps.platform.outputs.repo }}/\.github/workflows/release\.yaml@refs/tags/[^/]+'
+          INPUTS_TOOL: ${{ inputs.tool }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
+          STEPS_PLATFORM_OUTPUTS_EXT: ${{ steps.platform.outputs.ext }}
+          STEPS_PLATFORM_OUTPUTS_REPO: ${{ steps.platform.outputs.repo }}
+          INPUTS_ATTESTATION_FILE: ${{ inputs.attestation-file }}
+          INPUTS_POLICY: ${{ inputs.policy }}
+          STEPS_BOOTSTRAP_OUTPUTS_AMPEL_PATH: ${{ steps.bootstrap.outputs.ampel-path }}
         run: |
-          echo "::group::Verify ${{ inputs.tool }} ${{ inputs.version }}"
+          echo "::group::Verify ${INPUTS_TOOL} ${INPUTS_VERSION}"
 
           args=(verify)
-          args+=(--subject="${{ inputs.install-dir }}/bin/${{ inputs.tool }}${{ steps.platform.outputs.ext }}")
-          args+=(--collector="https://github.com/carabiner-dev/${{ steps.platform.outputs.repo }}/releases/download/${{ inputs.version }}/${{ inputs.attestation-file }}")
-          args+=(--policy="${{ inputs.policy }}")
+          args+=(--subject="${INPUTS_INSTALL_DIR}/bin/${INPUTS_TOOL}${STEPS_PLATFORM_OUTPUTS_EXT}")
+          args+=(--collector="https://github.com/carabiner-dev/${STEPS_PLATFORM_OUTPUTS_REPO}/releases/download/${INPUTS_VERSION}/${INPUTS_ATTESTATION_FILE}")
+          args+=(--policy="${INPUTS_POLICY}")
 
           if [ -n "$CONTEXT_INPUT" ]; then
             while IFS= read -r line; do
@@ -139,15 +158,21 @@ runs:
             args+=(--signer "$DEFAULT_SIGNER")
           fi
 
-          "${{ steps.bootstrap.outputs.ampel-path }}" "${args[@]}"
+          "${STEPS_BOOTSTRAP_OUTPUTS_AMPEL_PATH}" "${args[@]}"
           echo "::endgroup::"
 
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
         shell: bash
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "$env:INPUTS_INSTALL_DIR/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: pwsh
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
 
       - shell: bash
-        run: ${{ inputs.tool }} version
+        run: ${INPUTS_TOOL} version
+        env:
+          INPUTS_TOOL: ${{ inputs.tool }}

--- a/install/vexflow/action.yaml
+++ b/install/vexflow/action.yaml
@@ -44,15 +44,21 @@ runs:
       - name: Build
         shell: bash
         run: |
-          mkdir -p ${{ inputs.install-dir }}/bin || :
-          curl -Lo ${{ inputs.install-dir }}/bin/vexflow https://github.com/carabiner-dev/vexflow/releases/download/v0.0.1-pre3/vexflow-v0.0.1-pre3-linux-amd64
-          chmod 0755 ${{ inputs.install-dir }}/bin/vexflow
+          mkdir -p ${INPUTS_INSTALL_DIR}/bin || :
+          curl -Lo ${INPUTS_INSTALL_DIR}/bin/vexflow https://github.com/carabiner-dev/vexflow/releases/download/v0.0.1-pre3/vexflow-v0.0.1-pre3-linux-amd64
+          chmod 0755 ${INPUTS_INSTALL_DIR}/bin/vexflow
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${{ inputs.install-dir }}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
         shell: bash
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "${{ inputs.install-dir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: bash
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       
       - shell: bash
         run: vexflow --help

--- a/slsa/generate/action.yml
+++ b/slsa/generate/action.yml
@@ -79,32 +79,39 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        STEPS_BUILD_TEJOLOTE_OUTPUTS_BIN: ${{ steps.build-tejolote.outputs.bin }}
+        INPUTS_OUTPUT: ${{ inputs.output }}
+        INPUTS_SLSA_VERSION: ${{ inputs.slsa-version }}
+        INPUTS_SIGN: ${{ inputs.sign }}
+        INPUTS_WATCH_JOBS: ${{ inputs.watch-jobs }}
+        INPUTS_ARTIFACTS: ${{ inputs.artifacts }}
+        INPUTS_DEPENDENCIES: ${{ inputs.dependencies }}
       run: |
         set -euo pipefail
 
-        TEJOLOTE="${{ steps.build-tejolote.outputs.bin }}"
+        TEJOLOTE="${STEPS_BUILD_TEJOLOTE_OUTPUTS_BIN}"
         SPEC_URL="github://${{ github.repository }}/${{ github.run_id }}"
-        OUTPUT="${{ inputs.output }}"
+        OUTPUT="${INPUTS_OUTPUT}"
 
         ARGS=(
           "$SPEC_URL"
-          --slsa="${{ inputs.slsa-version }}"
+          --slsa="${INPUTS_SLSA_VERSION}"
           --output="$OUTPUT"
         )
 
         # Signing
-        if [[ "${{ inputs.sign }}" == "true" ]]; then
+        if [[ "${INPUTS_SIGN}" == "true" ]]; then
           ARGS+=(--sign)
         fi
 
         # Watch specific jobs if specified
-        if [[ -n "${{ inputs.watch-jobs }}" ]]; then
-          ARGS+=(--watch-jobs="${{ inputs.watch-jobs }}")
+        if [[ -n "${INPUTS_WATCH_JOBS}" ]]; then
+          ARGS+=(--watch-jobs="${INPUTS_WATCH_JOBS}")
         fi
 
         # Additional artifact sources
-        if [[ -n "${{ inputs.artifacts }}" ]]; then
-          IFS=',' read -ra ARTIFACT_URIS <<< "${{ inputs.artifacts }}"
+        if [[ -n "${INPUTS_ARTIFACTS}" ]]; then
+          IFS=',' read -ra ARTIFACT_URIS <<< "${INPUTS_ARTIFACTS}"
           for uri in "${ARTIFACT_URIS[@]}"; do
             uri=$(echo "$uri" | xargs)  # trim whitespace
             if [[ -n "$uri" ]]; then
@@ -114,8 +121,8 @@ runs:
         fi
 
         # Additional dependencies
-        if [[ -n "${{ inputs.dependencies }}" ]]; then
-          IFS=',' read -ra DEP_URIS <<< "${{ inputs.dependencies }}"
+        if [[ -n "${INPUTS_DEPENDENCIES}" ]]; then
+          IFS=',' read -ra DEP_URIS <<< "${INPUTS_DEPENDENCIES}"
           for uri in "${DEP_URIS[@]}"; do
             uri=$(echo "$uri" | xargs)
             if [[ -n "$uri" ]]; then


### PR DESCRIPTION
Zizmor flagged a few warnings in these files.

A few fixes here:

1. Adding zizmor as a workflow that runs for PRs and pushes to main.
2. Applying zizmor --fix on most of the files.
    - The ENV name is derived from the prior usage.  E.g. `${{ steps.bootstrap.outputs.ampel-path }}` becomes `${STEPS_BOOTSTRAP_OUTPUTS_AMPEL_PATH}`
3. Some additional manual fixes to ampel/verify/action.yml to resolve some likely context corruption (this could use a second look).