### PR TITLE
Zizmor fixes, tighten severity to medium

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"  # zizmor: ignore[dependabot-cooldown] disabled for now
     directories:
       - "drop"
       - "install/*"

--- a/.github/workflows/test-installers.yaml
+++ b/.github/workflows/test-installers.yaml
@@ -7,8 +7,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-installers:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +60,8 @@ jobs:
         run: ${{ matrix.tool }} --help
 
   test-download-and-verify:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/_demo/scorecard/action.yml
+++ b/_demo/scorecard/action.yml
@@ -19,6 +19,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Validate install-dir
+        shell: bash
+        run: |
+          case "$INPUTS_INSTALL_DIR" in
+            ''|*[!A-Za-z0-9._/\$~-]*)
+              echo "::error::install-dir must be non-empty and contain only [A-Za-z0-9._/\$~-]; got: $INPUTS_INSTALL_DIR"
+              exit 1
+              ;;
+          esac
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -45,12 +57,12 @@ runs:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
 
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH # zizmor: ignore[github-env] install-dir validated upstream
         shell: bash
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append # zizmor: ignore[github-env] install-dir validated upstream
         shell: bash
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}

--- a/drop/action.yml
+++ b/drop/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: '$HOME/.carabiner'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/carabiner-dev/drop'
+  image: 'docker://ghcr.io/carabiner-dev/drop@sha256:42beb1f44a5d0eca5d740d64364560f38e7af37965c8b73aafdfe2bcff1ae308'
   args:
     - get
     - --insecure=${{ inputs.insecure }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -58,6 +58,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Validate install-dir
+        shell: bash
+        run: |
+          case "$INPUTS_INSTALL_DIR" in
+            ''|*[!A-Za-z0-9._/\$~-]*)
+              echo "::error::install-dir must be non-empty and contain only [A-Za-z0-9._/\$~-]; got: $INPUTS_INSTALL_DIR"
+              exit 1
+              ;;
+          esac
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
+
       - name: Bootstrap trusted ampel
         if: inputs.verify == 'true'
         uses: carabiner-dev/actions/install/ampel-bootstrap@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
@@ -162,12 +174,12 @@ runs:
           echo "::endgroup::"
 
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH # zizmor: ignore[github-env] install-dir validated upstream
         shell: bash
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "$env:INPUTS_INSTALL_DIR/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "$env:INPUTS_INSTALL_DIR/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append # zizmor: ignore[github-env] install-dir validated upstream
         shell: pwsh
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}

--- a/install/vexflow/action.yaml
+++ b/install/vexflow/action.yaml
@@ -19,6 +19,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Validate install-dir
+        shell: bash
+        run: |
+          case "$INPUTS_INSTALL_DIR" in
+            ''|*[!A-Za-z0-9._/\$~-]*)
+              echo "::error::install-dir must be non-empty and contain only [A-Za-z0-9._/\$~-]; got: $INPUTS_INSTALL_DIR"
+              exit 1
+              ;;
+          esac
+        env:
+          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
+
       # - name: Checkout code
       #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       #   with:
@@ -50,12 +62,12 @@ runs:
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
+        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH # zizmor: ignore[github-env] install-dir validated upstream
         shell: bash
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
       - if: ${{ runner.os == 'Windows' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append # zizmor: ignore[github-env] install-dir validated upstream
         shell: bash
         env:
           INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}


### PR DESCRIPTION
This PR is a follo-up to #59 and it addresses some of the remaining findings from the zizmor action. Essentially:

- We add a missing image pin on the experimental drop action
- Add missing permissions on the installer testers
- Sanitize the install directory name and handle messages
- Disable dependabot cooldown checks
