### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ its attestations against a policy.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     policy: 'path/to/policy.yaml'   # URI or path to policy code
     subject: 'path/to/artifact'     # or digest, eg sha256:98349875bf3e09...
@@ -45,7 +45,7 @@ its attestations against a policy.
 **Basic verification:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/binary'
@@ -55,7 +55,7 @@ its attestations against a policy.
 **Verification with custom attestations:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     policy: '.ampel/policy.yaml'
     subject: 'sha256:abc123...'
@@ -67,7 +67,7 @@ its attestations against a policy.
 **Verification with attestation push:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -80,7 +80,7 @@ its attestations against a policy.
 **Verification without failing the workflow:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -98,7 +98,7 @@ codebase IDs.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     ecosystems: |
       golang

--- a/go/README.md
+++ b/go/README.md
@@ -32,7 +32,7 @@ used internally by `go/check-latest` and `go/check-previous`.
 ```yaml
 - name: Resolve Go versions
   id: go-versions
-  uses: carabiner-dev/actions/go/versions@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 
 - name: Set up Go
   uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -55,13 +55,13 @@ doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/go/check-latest@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 With a custom go.mod path:
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/go/check-latest@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     go-mod-path: 'src/go.mod'
 ```
@@ -89,7 +89,7 @@ error message if the version doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-previous@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/go/check-previous@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 On failure, the action produces an error like:
@@ -118,13 +118,13 @@ Go is already installed on the runner (e.g. via `actions/setup-go`).
   with:
     go-version-file: 'go.mod'
 
-- uses: carabiner-dev/actions/go/modtidy@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/go/modtidy@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 With a custom working directory:
 
 ```yaml
-- uses: carabiner-dev/actions/go/modtidy@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/go/modtidy@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
   with:
     working-directory: 'src'
 ```
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - id: go-versions
-        uses: carabiner-dev/actions/go/versions@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+        uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
       - id: matrix
         run: |
           echo "go-versions=[\"${{ steps.go-versions.outputs.GO_VERSION_STABLE }}\",\"${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}\"]" >> "$GITHUB_OUTPUT"

--- a/slsa/generate/README.md
+++ b/slsa/generate/README.md
@@ -43,7 +43,7 @@ jobs:
       contents: read
       actions: read      # Read run metadata and artifacts
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 ### Watch specific jobs
@@ -69,7 +69,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
         with:
           watch-jobs: "build, integration-tests"
 ```
@@ -84,7 +84,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
         with:
           artifacts: "oci://ghcr.io/my-org/my-image"
           dependencies: "git+https://github.com/my-org/my-lib@abc123def"

--- a/unpack/sbom/README.md
+++ b/unpack/sbom/README.md
@@ -10,7 +10,7 @@ format.
 ## Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+- uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 That's it. With no inputs, the action will:
@@ -73,7 +73,7 @@ When the CycloneDX format is used, the extension is `.cdx.json` instead of `.spd
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 ```
 
 ### Generate only for Go and npm ecosystems
@@ -81,7 +81,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     with:
       ecosystems: |
         golang
@@ -93,7 +93,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     with:
       codebases: |
         golang:.
@@ -105,7 +105,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     with:
       format: cyclonedx
       files: 'true'
@@ -117,7 +117,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     with:
       ignore: |
         vendor
@@ -130,7 +130,7 @@ steps:
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     with:
       output-path: /tmp
       push-to-release: ${{ steps.tag.outputs.tag_name }}
@@ -144,7 +144,7 @@ steps:
 steps:
   - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-  - uses: carabiner-dev/actions/unpack/sbom@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
+  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
     id: sbom
     with:
       output-path: sboms/


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v6.0.3` | `df4cb1c069e1` |
| `actions/setup-go` | `v6.4.0` | `4a3601121dd0` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.2.1` | `94f29392187f` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>