### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -35,7 +35,7 @@ used internally by `go/check-latest` and `go/check-previous`.
   uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
 
 - name: Set up Go
-  uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+  uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
   with:
     go-version: ${{ steps.go-versions.outputs.GO_VERSION_STABLE }}
 ```
@@ -114,7 +114,7 @@ Go is already installed on the runner (e.g. via `actions/setup-go`).
 ### Usage
 
 ```yaml
-- uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+- uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
   with:
     go-version-file: 'go.mod'
 
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test ./...


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v7.0.0` | `9c091bb21b7c` |
| `actions/setup-go` | `v6.5.0` | `924ae3a1cded` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.2.1` | `94f29392187f` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>