### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       id-token: write   # required to mint the workflow OIDC token
       contents: read
     steps:
-      - uses: carabiner-dev/actions/login@main # pin to a release commit once tagged
+      - uses: carabiner-dev/actions/login@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1 # pin to a release commit once tagged
       # CARABINER_CREDENTIALS is now set for subsequent steps
 ```
 

--- a/login/README.md
+++ b/login/README.md
@@ -92,7 +92,7 @@ jobs:
       id-token: write   # required to mint the workflow OIDC token
       contents: read
     steps:
-      - uses: carabiner-dev/actions/login@main # pin to a release commit once tagged
+      - uses: carabiner-dev/actions/login@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1 # pin to a release commit once tagged
 
       # Subsequent steps can read CARABINER_CREDENTIALS from the environment.
       - run: echo "token expires in ${{ steps.login.outputs.expires-in }}s"


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v7.0.0` | `9c091bb21b7c` |
| `actions/setup-go` | `v6.5.0` | `924ae3a1cded` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.2.1` | `94f29392187f` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>