### PR TITLE
Add resources to login action

### DIFF
--- a/login/README.md
+++ b/login/README.md
@@ -28,7 +28,7 @@ The exchange is **refused** (no token issued) unless both conditions hold:
 
 - the repository's GitHub organization is claimed as a **namespace** by a
   Carabiner organization, and
-- the repository has at least one **monitored pipeline**.
+- the repository is tracked in the namespace.
 
 If either is missing, the action fails with the exchange server's error.
 
@@ -36,8 +36,9 @@ If either is missing, the action fails with the exchange server's error.
 
 The issued token can carry **capability scopes** (for example
 `attestations:read attestations:write`, the default). Scopes are capability
-switches: they are necessary to use a capability but not sufficient — the
-platform always checks the actual authorization live when the token is used.
+switches: they are necessary to use a capability but not sufficient, the
+platform always checks the actual authorization of the repository's service
+account when the token is used.
 
 The action requests the scopes in the `scope` input, and the server mints the
 token with the **intersection** of the requested and granted scopes (it never
@@ -55,11 +56,29 @@ Set `scope: ""` to request an **identity-only** token that carries no
 capability scopes. In every case the [authorization
 prerequisites](#authorization) above still apply.
 
+## Resources
+
+The issued token also carries a **resources** claim: the canonical resource
+URIs the token can act on. By default the server stamps the repository's whole
+Carabiner organization (`organization://<handle>`). Pass space-separated URIs
+in the `resource` input to restrict the token further:
+
+- `organization://<handle>`: the whole organization.
+- `repository://<system>/<owner>/<repo>`: one registered repository
+  (registry slug form, eg `repository://github/acme/widgets`).
+- `stash://<handle>[/<namespace>]`: the organization's attestation stash or
+  a namespace in it.
+
+Every requested resource must belong to the repository's Carabiner
+organization as specifying anything else refuses the exchange. Like scopes,
+resources only attenuate, live authorization still applies wherever the
+token is used. Older exchange servers ignore the parameter.
+
 ## Token lifetime
 
 The issued token's expiry is paired to the workflow's OIDC token, so it is
-naturally short-lived (a few minutes). Treat it as ephemeral — request it in the
-job that uses it rather than passing it between jobs.
+naturally short-lived (a few minutes). Treat it as ephemeral and request it in
+the job that uses it rather than passing it between jobs.
 
 ## Requirements
 
@@ -74,6 +93,7 @@ job that uses it rather than passing it between jobs.
 | `exchange-url` | No | `https://auth.carabiner.dev` | Base URL of the Carabiner token exchange server. The workflow OIDC token is minted for this audience. |
 | `audience` | No | `https://api.carabiner.dev` | Audience (a Carabiner service URL) to request the token for. Must be on the exchange server's allowlist. |
 | `scope` | No | `attestations:read attestations:write` | Space-separated capability scopes to request. The issued token carries the intersection of the requested and granted scopes; set empty for an identity-only token. |
+| `resource` | No | _(empty)_ | Space-separated canonical resource URIs restricting which platform objects the token may act on. All resources must belong to the repository's Carabiner organization, an empty resource requests the repository organization. |
 
 ## Outputs
 
@@ -108,12 +128,15 @@ the environment.
 
 ## Troubleshooting
 
-- **"No OIDC token available"** — the calling job is missing
+- **"No OIDC token available"**: the calling job is missing
   `permissions: id-token: write`.
-- **"Token exchange was refused"** — the repository's organization is not
+- **"Token exchange was refused"**: the repository's organization is not
   claimed as a Carabiner namespace, or the repository has no monitored pipeline.
 - **`invalid_scope`** — none of the requested scopes are granted to the
   repository; an organization admin can grant them in Carabiner, or set
   `scope: ""` for an identity-only token.
-- **"Could not reach the carabiner token exchange server"** — check
+- **`invalid_scope` mentioning a resource**: a URI in the `resource` input is
+  outside the repository's Carabiner organization (or names an unregistered
+  repository); fix or drop the entry.
+- **"Could not reach the carabiner token exchange server"**: check
   `exchange-url` and network egress from the runner.

--- a/login/action.yml
+++ b/login/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Space-separated capability scopes to request. The issued token carries the intersection of the requested and granted scopes; set empty for an identity-only token.'
     required: false
     default: "attestations:read attestations:write"
+  resource:
+    description: 'Space-separated canonical resource URIs (organization://<handle>, repository://<system>/<owner>/<repo>, stash://<handle>[/<namespace>]) restricting which platform objects the token may act on. All must belong to the repository''s Carabiner organization; empty requests the server default (the whole organization).'
+    required: false
+    default: ""
 outputs:
   expires-in:
     description: 'Lifetime of the issued carabiner token, in seconds'
@@ -64,6 +68,14 @@ runs:
         if [ -n "${requested_scope}" ]; then
           scope_args+=(--data-urlencode "scope=${requested_scope}")
         fi
+        # Resources restrict which platform objects the token may act on.
+        # RFC 8693 takes one resource parameter per URI; empty lets the server
+        # stamp its default (the repository's whole organization).
+        requested_resources="$(printf '%s' "${INPUTS_RESOURCE}" | xargs)"
+        resource_args=()
+        for res in ${requested_resources}; do
+          resource_args+=(--data-urlencode "resource=${res}")
+        done
         response="$(curl -sS -w '\n%{http_code}' \
           -X POST "${INPUTS_EXCHANGE_URL%/}/token" \
           --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
@@ -71,7 +83,8 @@ runs:
           --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:jwt" \
           --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:jwt" \
           --data-urlencode "audience=${INPUTS_AUDIENCE}" \
-          ${scope_args[@]+"${scope_args[@]}"})" || {
+          ${scope_args[@]+"${scope_args[@]}"} \
+          ${resource_args[@]+"${resource_args[@]}"})" || {
           echo "::error::Could not reach the carabiner token exchange server at ${INPUTS_EXCHANGE_URL}"
           exit 1
         }
@@ -82,7 +95,10 @@ runs:
           err="$(printf '%s' "${body}" | jq -r '.error // empty' 2>/dev/null || true)"
           desc="$(printf '%s' "${body}" | jq -r '.error_description // .error // "unknown error"' 2>/dev/null || echo "unknown error")"
           if [ "${err}" = "invalid_scope" ]; then
-            desc="${desc} None of the requested scopes are granted to this repository — an organization admin can grant them in Carabiner."
+            case "${desc}" in
+              *resource*) desc="${desc} Requested resources must belong to the repository's Carabiner organization." ;;
+              *) desc="${desc} None of the requested scopes are granted to this repository — an organization admin can grant them in Carabiner." ;;
+            esac
           fi
           echo "::error::Token exchange was refused (HTTP ${http_code}): ${desc}"
           exit 1
@@ -120,3 +136,4 @@ runs:
         INPUTS_EXCHANGE_URL: ${{ inputs.exchange-url }}
         INPUTS_AUDIENCE: ${{ inputs.audience }}
         INPUTS_SCOPE: ${{ inputs.scope }}
+        INPUTS_RESOURCE: ${{ inputs.resource }}


### PR DESCRIPTION
This pull request adds support for restricting Carabiner-issued tokens to specific platform resources, in addition to capability scopes. It introduces a new `resource` input to the action, updates the documentation to explain resource claims and their usage, and improves error handling for resource-related issues.

**Resource restriction support:**

* [`login/action.yml`](diffhunk://#diff-4fd7517004b079d0d19c104a37d39bed67e22016c8c7756703afa7ea11f781e1R23-R26): Adds a new `resource` input, allowing users to specify space-separated canonical resource URIs (e.g., `organization://<handle>`, `repository://<system>/<owner>/<repo>`, `stash://<handle>[/<namespace>]`) to restrict which platform objects the token may act on. The action passes these as `resource` parameters to the token exchange server. [[1]](diffhunk://#diff-4fd7517004b079d0d19c104a37d39bed67e22016c8c7756703afa7ea11f781e1R23-R26) [[2]](diffhunk://#diff-4fd7517004b079d0d19c104a37d39bed67e22016c8c7756703afa7ea11f781e1R71-R87) [[3]](diffhunk://#diff-4fd7517004b079d0d19c104a37d39bed67e22016c8c7756703afa7ea11f781e1R139)
* [`login/README.md`](diffhunk://#diff-e6d91a73f54bfeae43ad5d30619a3eab6997a7c6f9e14fe8f41fd1d135ed6033R59-R81): Documents the new resource restriction feature, including the format of resource URIs, default behavior, and validation rules. [[1]](diffhunk://#diff-e6d91a73f54bfeae43ad5d30619a3eab6997a7c6f9e14fe8f41fd1d135ed6033R59-R81) [[2]](diffhunk://#diff-e6d91a73f54bfeae43ad5d30619a3eab6997a7c6f9e14fe8f41fd1d135ed6033R96)

**Error handling improvements:**

* [`login/action.yml`](diffhunk://#diff-4fd7517004b079d0d19c104a37d39bed67e22016c8c7756703afa7ea11f781e1L85-R101): Improves error messages for `invalid_scope` errors related to resources, clarifying when a requested resource is outside the repository's Carabiner organization.
* [`login/README.md`](diffhunk://#diff-e6d91a73f54bfeae43ad5d30619a3eab6997a7c6f9e14fe8f41fd1d135ed6033L111-R141): Updates troubleshooting section to include new error cases for invalid resources.

**Other documentation clarifications:**

* [`login/README.md`](diffhunk://#diff-e6d91a73f54bfeae43ad5d30619a3eab6997a7c6f9e14fe8f41fd1d135ed6033L31-R41): Clarifies token issuance requirements (repository must be tracked in the namespace), and updates explanations of scope and authorization checks.

These changes make the action more flexible and secure by allowing fine-grained resource restrictions on issued tokens.