### PR TITLE
Update SLSA provenance generator

### DIFF
--- a/.github/workflows/test-slsa-generate.yaml
+++ b/.github/workflows/test-slsa-generate.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test SLSA Generate
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Produce an artifact to be attested by the provenance action.
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Create a file to attest
+        shell: bash
+        run: echo "carabiner slsa/generate test artifact — run ${GITHUB_RUN_ID}" > artifact.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-artifact
+          path: artifact.txt
+
+  # Observe the build job and generate a signed SLSA provenance attestation
+  # covering its uploaded artifact, then publish the attestation as an artifact.
+  provenance:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # Sigstore keyless signing
+      contents: read
+      actions: read     # Read run metadata and artifacts
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Generate provenance
+        id: slsa
+        uses: ./slsa/generate
+        with:
+          # Watch only the build job; watching the whole run would include the
+          # verify job (which needs this one) and deadlock.
+          watch-jobs: build
+
+      - name: Upload provenance attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provenance
+          path: ${{ steps.slsa.outputs.attestation }}
+
+  # Download the artifact and its provenance, then verify the attestation with
+  # ampel: the subject must be covered by a SLSA provenance signed by this
+  # workflow's Sigstore identity.
+  verify:
+    needs: [build, provenance]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-artifact
+          path: subject
+
+      - name: Download provenance attestation
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provenance
+          path: attestations
+
+      - name: Verify artifact provenance with ampel
+        uses: ./ampel/verify
+        with:
+          subject: subject/artifact.txt
+          collector: "fs:attestations"
+          policy: "git+https://github.com/carabiner-dev/policies#slsa/has-attestation.json"
+          signer: 'sigstore(regexp)::https://token\.actions\.githubusercontent\.com::https://github\.com/carabiner-dev/actions/\.github/workflows/test-slsa-generate\.yaml@refs/.+'
+          attest: "false"

--- a/slsa/generate/README.md
+++ b/slsa/generate/README.md
@@ -20,6 +20,20 @@ The attestation is signed using [Sigstore](https://sigstore.dev) keyless
 signing, binding the provenance to the GitHub Actions OIDC identity of the
 workflow.
 
+## Verifying the tejolote download
+
+The action downloads a released `tejolote` binary from
+[kubernetes-sigs/tejolote](https://github.com/kubernetes-sigs/tejolote/releases)
+rather than building it from source. Before use, the binary is verified with the
+[`ampel/verify`](../../ampel/verify) action against tejolote's own signed SLSA
+provenance attestation. The default `policy`
+([`slsa/slsa-build-point`](https://github.com/carabiner-dev/policies/blob/main/slsa/slsa-build-point.json))
+requires that provenance to be signed by tejolote's release-workflow Sigstore
+identity and to record the expected `build-point` (the tejolote source
+repository), so a binary built from anywhere else fails verification. Set
+`verify: false` to skip this (e.g. for air-gapped runners or when pinning an
+unreleased build).
+
 ## Usage
 
 ### Minimal (watch all sibling jobs automatically)
@@ -74,7 +88,7 @@ jobs:
           watch-jobs: "build, integration-tests"
 ```
 
-### With additional artifact sources
+### With external artifact sources
 
 ```yaml
   provenance:
@@ -90,6 +104,10 @@ jobs:
           dependencies: "git+https://github.com/my-org/my-lib@abc123def"
 ```
 
+> **Note:** Setting `artifacts` makes tejolote collect **only** from the URIs you
+> list; the run's GitHub Actions artifacts are no longer collected automatically.
+> Leave `artifacts` empty to keep the automatic collection.
+
 ## Inputs
 
 | Name | Description | Default |
@@ -98,8 +116,15 @@ jobs:
 | `slsa-version` | SLSA predicate version (`1.0` or `0.2`) | `1.0` |
 | `output` | Path to write the attestation file | `provenance.intoto.jsonl` |
 | `watch-jobs` | Comma-separated job names to watch (empty = all siblings) | `""` |
-| `artifacts` | Comma-separated artifact storage URIs | `""` |
+| `artifacts` | Comma-separated storage URIs to collect from. When set, tejolote collects **only** from these and skips the run's automatic GitHub Actions artifacts | `""` |
+| `expand-artifacts` | Unpack GitHub Actions artifact archives and attest each contained file; `false` attests each archive as one subject | `true` |
+| `artifacts-filter` | Glob (path.Match) matched against artifact names; only matching artifacts are attested (all sources) | `""` |
 | `dependencies` | Comma-separated dependency URIs to record | `""` |
+| `timeout` | Max time to wait for watched build jobs (Go duration, `0` disables) | `20m` |
+| `tejolote-version` | Released tejolote version to download and run | `v0.5.0` |
+| `verify` | Verify the downloaded tejolote binary with the `ampel/verify` action against its signed SLSA provenance | `true` |
+| `policy` | Ampel policy locator applied when verifying the download | pinned `slsa/slsa-build-point` |
+| `build-point` | Expected source repository (VCS URI) the default policy checks in the provenance | `git+ssh://github.com/kubernetes-sigs/tejolote` |
 
 ## Outputs
 

--- a/slsa/generate/action.yml
+++ b/slsa/generate/action.yml
@@ -30,9 +30,24 @@ inputs:
     default: ""
   artifacts:
     description: >-
-      Comma-separated list of additional artifact storage URIs to collect
-      from (e.g. 'oci://registry/image,gs://bucket/path'). GitHub Actions
-      artifacts from the run are always collected automatically.
+      Comma-separated list of artifact storage URIs to collect from
+      (e.g. 'oci://registry/image,gs://bucket/path'). When empty, the run's
+      GitHub Actions artifacts are collected automatically. When set, tejolote
+      collects only from these URIs and does not collect the run's native
+      GitHub Actions artifacts.
+    required: false
+    default: ""
+  expand-artifacts:
+    description: >-
+      When true (default), unpack archive-wrapped GitHub Actions artifacts and
+      record one subject per contained file. When false, attest each archive as
+      a single subject.
+    required: false
+    default: "true"
+  artifacts-filter:
+    description: >-
+      Glob (path.Match syntax) matched against artifact names; when set, only
+      matching artifacts are attested. Applies to all artifact sources.
     required: false
     default: ""
   dependencies:
@@ -41,6 +56,32 @@ inputs:
       (e.g. 'git+https://github.com/org/repo@sha,image@sha256:digest')
     required: false
     default: ""
+  timeout:
+    description: "Max time to wait for the watched build jobs to complete (Go duration, e.g. 20m). 0 disables the timeout."
+    required: false
+    default: "20m"
+  tejolote-version:
+    description: "Released tejolote version to download and run"
+    required: false
+    default: "v0.5.0"
+  verify:
+    description: >-
+      Verify the downloaded tejolote binary with ampel against its signed
+      SLSA provenance attestation before use.
+    required: false
+    default: "true"
+  policy:
+    description: >-
+      Ampel policy locator (path, URL, or VCS locator) applied when verifying
+      the tejolote download.
+    required: false
+    default: "git+https://github.com/carabiner-dev/policies@eed2d09ac2a7f8f5238a24b30492e378d8d77ad3#slsa/slsa-build-point.json"
+  build-point:
+    description: >-
+      Expected source build point (VCS URI) that the default policy checks
+      against the tejolote provenance.
+    required: false
+    default: "git+ssh://github.com/kubernetes-sigs/tejolote"
 
 outputs:
   attestation:
@@ -50,46 +91,87 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: "1.26.2"
-        cache: false
-
-    - name: Checkout tejolote
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: kubernetes-sigs/tejolote
-        ref: main
-        path: .tejolote-src
-        persist-credentials: false
-
-    - name: Build tejolote from source
-      id: build-tejolote
+    - name: Install tejolote
+      id: install-tejolote
       shell: bash
+      env:
+        INPUTS_TEJOLOTE_VERSION: ${{ inputs.tejolote-version }}
+        INPUTS_VERIFY: ${{ inputs.verify }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
       run: |
-        cd .tejolote-src
-        go build -o tejolote ./cmd/tejolote
-        TEJOLOTE_BIN="$(pwd)/tejolote"
-        echo "bin=$TEJOLOTE_BIN" >> "$GITHUB_OUTPUT"
-        "$TEJOLOTE_BIN" version || "$TEJOLOTE_BIN" --help | head -5
+        set -euo pipefail
+
+        case "${RUNNER_OS}" in
+          Linux)   os="linux" ;;
+          macOS)   os="darwin" ;;
+          Windows) os="windows" ;;
+          *) echo "::error::Unsupported OS: ${RUNNER_OS}"; exit 1 ;;
+        esac
+
+        case "${RUNNER_ARCH}" in
+          X64)   arch="amd64" ;;
+          ARM64) arch="arm64" ;;
+          *) echo "::error::Unsupported architecture: ${RUNNER_ARCH}"; exit 1 ;;
+        esac
+
+        ext=""
+        if [ "${os}" = "windows" ]; then
+          ext=".exe"
+        fi
+
+        VERSION="${INPUTS_TEJOLOTE_VERSION}"
+        BASE="https://github.com/kubernetes-sigs/tejolote/releases/download/${VERSION}"
+        DIR="$(mktemp -d)"
+        BIN="${DIR}/tejolote${ext}"
+
+        echo "Downloading tejolote ${VERSION} (${os}/${arch})"
+        curl -sSfL --retry 3 --retry-delay 2 \
+          -o "${BIN}" "${BASE}/tejolote-${arch}-${os}${ext}"
+        chmod 0755 "${BIN}"
+        echo "bin=${BIN}" >> "${GITHUB_OUTPUT}"
+
+        # When verifying, fetch the signed SLSA provenance into its own directory
+        # so the ampel filesystem collector can read it as an attestation source.
+        if [ "${INPUTS_VERIFY}" = "true" ]; then
+          ATT_DIR="${DIR}/attestations"
+          mkdir -p "${ATT_DIR}"
+          curl -sSfL --retry 3 --retry-delay 2 \
+            -o "${ATT_DIR}/tejolote-${VERSION}.provenance.json" \
+            "${BASE}/tejolote-${VERSION}.provenance.json"
+          echo "attest-dir=${ATT_DIR}" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Verify tejolote provenance
+      if: inputs.verify == 'true'
+      uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      with:
+        subject: ${{ steps.install-tejolote.outputs.bin }}
+        collector: "fs:${{ steps.install-tejolote.outputs.attest-dir }}"
+        policy: ${{ inputs.policy }}
+        signer: "sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/${{ inputs.tejolote-version }}"
+        context: "buildPoint:${{ inputs.build-point }}"
+        attest: "false"
 
     - name: Generate provenance attestation
       id: attest
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        STEPS_BUILD_TEJOLOTE_OUTPUTS_BIN: ${{ steps.build-tejolote.outputs.bin }}
+        STEPS_INSTALL_TEJOLOTE_OUTPUTS_BIN: ${{ steps.install-tejolote.outputs.bin }}
         INPUTS_OUTPUT: ${{ inputs.output }}
         INPUTS_SLSA_VERSION: ${{ inputs.slsa-version }}
         INPUTS_SIGN: ${{ inputs.sign }}
         INPUTS_WATCH_JOBS: ${{ inputs.watch-jobs }}
         INPUTS_ARTIFACTS: ${{ inputs.artifacts }}
         INPUTS_DEPENDENCIES: ${{ inputs.dependencies }}
+        INPUTS_TIMEOUT: ${{ inputs.timeout }}
+        INPUTS_EXPAND_ARTIFACTS: ${{ inputs.expand-artifacts }}
+        INPUTS_ARTIFACTS_FILTER: ${{ inputs.artifacts-filter }}
       run: |
         set -euo pipefail
 
-        TEJOLOTE="${STEPS_BUILD_TEJOLOTE_OUTPUTS_BIN}"
+        TEJOLOTE="${STEPS_INSTALL_TEJOLOTE_OUTPUTS_BIN}"
         SPEC_URL="github://${{ github.repository }}/${{ github.run_id }}"
         OUTPUT="${INPUTS_OUTPUT}"
 
@@ -107,6 +189,21 @@ runs:
         # Watch specific jobs if specified
         if [[ -n "${INPUTS_WATCH_JOBS}" ]]; then
           ARGS+=(--watch-jobs="${INPUTS_WATCH_JOBS}")
+        fi
+
+        # Watch timeout
+        if [[ -n "${INPUTS_TIMEOUT}" ]]; then
+          ARGS+=(--watch-timeout="${INPUTS_TIMEOUT}")
+        fi
+
+        # Artifact expansion (GitHub Actions archives)
+        if [[ -n "${INPUTS_EXPAND_ARTIFACTS}" ]]; then
+          ARGS+=(--expand-artifacts="${INPUTS_EXPAND_ARTIFACTS}")
+        fi
+
+        # Artifact name filter
+        if [[ -n "${INPUTS_ARTIFACTS_FILTER}" ]]; then
+          ARGS+=(--artifacts-filter="${INPUTS_ARTIFACTS_FILTER}")
         fi
 
         # Additional artifact sources
@@ -137,8 +234,3 @@ runs:
         echo "::endgroup::"
 
         echo "attestation=$OUTPUT" >> "$GITHUB_OUTPUT"
-
-    - name: Clean up tejolote source
-      if: always()
-      shell: bash
-      run: rm -rf .tejolote-src


### PR DESCRIPTION
This commit updates the SLSA prrovenance generation action to use the latest tejolote release, exposing some of its new features in the action. We also now have an e2e test to ensure the attester can observe and always generate a valid attestation.