### PR TITLE
Bump internal action pins to v1.2.2

### DIFF
--- a/ampel/verify/action.yml
+++ b/ampel/verify/action.yml
@@ -61,7 +61,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/ampel@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+    # Pinned to the release carrying the current AMPEL default (v1.3.2). Keep
+    # this in step with install/ampel: pinning an older revision here silently
+    # holds the installed AMPEL back to that revision's default, regardless of
+    # any newer default in this repository.
+    - uses: carabiner-dev/actions/install/ampel@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       name: 🔴🟡🟢 AMPEL Setup
       id: install
 
@@ -130,7 +134,7 @@ runs:
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' }}
       name: Setup bnd
-      uses: carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+      uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' }}
       name: sign-ampel-results

--- a/beaker/tests/action.yml
+++ b/beaker/tests/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/beaker@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+    - uses: carabiner-dev/actions/install/beaker@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       name: Beaker Setup
       id: install
 
-    - uses: carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       name: bnd Setup
       id: install-bnd
 

--- a/bnd/sign/action.yml
+++ b/bnd/sign/action.yml
@@ -35,13 +35,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       name: Install bnd
       with:
         version: ${{ inputs.bnd-version }}
       if: ${{ inputs.bnd-version != '' }}
 
-    - uses: carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       name: Install bnd (latest)
       if: ${{ inputs.bnd-version == '' }}
 

--- a/go/check-latest/action.yml
+++ b/go/check-latest/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+      uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/go/check-previous/action.yml
+++ b/go/check-previous/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+      uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: ampel
         version: ${{ inputs.version }}

--- a/install/beaker/action.yml
+++ b/install/beaker/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::error::beaker does not have a Windows binary"
         exit 1
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: beaker
         version: ${{ inputs.version }}

--- a/install/bnd/action.yml
+++ b/install/bnd/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: bnd
         version: ${{ inputs.version }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -72,7 +72,7 @@ runs:
 
       - name: Bootstrap trusted ampel
         if: inputs.verify == 'true'
-        uses: carabiner-dev/actions/install/ampel-bootstrap@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+        uses: carabiner-dev/actions/install/ampel-bootstrap@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
         id: bootstrap
 
       - name: Detect platform

--- a/install/policyctl/action.yml
+++ b/install/policyctl/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: policyctl
         version: ${{ inputs.version }}

--- a/install/revex/action.yml
+++ b/install/revex/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: revex
         version: ${{ inputs.version }}

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: snappy
         version: ${{ inputs.version }}

--- a/install/unpack/action.yml
+++ b/install/unpack/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         tool: unpack
         version: ${{ inputs.version }}

--- a/slsa/generate/action.yml
+++ b/slsa/generate/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Verify tejolote provenance
       if: inputs.verify == 'true'
-      uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       with:
         subject: ${{ steps.install-tejolote.outputs.bin }}
         collector: "fs:${{ steps.install-tejolote.outputs.attest-dir }}"

--- a/unpack/sbom/action.yml
+++ b/unpack/sbom/action.yml
@@ -60,7 +60,7 @@ runs:
   using: "composite"
   steps:
     - name: Install unpack
-      uses: carabiner-dev/actions/install/unpack@2a11d59a135c5e291f305f249a92ad7903e3ee0f # v1.1.7
+      uses: carabiner-dev/actions/install/unpack@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 
     - name: Generate SBOMs
       id: generate


### PR DESCRIPTION
This pull request updates the version of several reusable GitHub Actions used throughout the repository to `v1.2.2` (commit `174f1c8`). The main purpose is to ensure consistency and keep dependencies up to date, which improves maintainability and security.

The most important changes are:

**Dependency Updates:**

* Updated all usages of `carabiner-dev/actions/install/download-and-verify`, `carabiner-dev/actions/install/ampel-bootstrap`, and related install actions to version `v1.2.2` (`174f1c8`) in their respective `action.yml` files. [[1]](diffhunk://#diff-aae9aed90f4ae8fed725248d50e623cddeb4263fd5cee6de824e2eb4c207339cL22-R22) [[2]](diffhunk://#diff-448cb2637f7183be7207acf442728f479bf8b49941fd0be47e2479086ae93591L27-R27) [[3]](diffhunk://#diff-5d07c7393bda00d4991c856a418381ba36cea0f4dc9ff1a14a07facf28ee64bdL22-R22) [[4]](diffhunk://#diff-9f6433605a0ca2bdd16be5d56f98fd05e3fbb5fbc35e485821800318b7a416feL22-R22) [[5]](diffhunk://#diff-179349cf5ec0f44987a118435c10aa89d9e696fa96afd5c5c359fdd60e4aa691L22-R22) [[6]](diffhunk://#diff-f1358eb1366db979b5f856b1ee3ec39580154869287c2a81bacb55993c87b977L22-R22) [[7]](diffhunk://#diff-1e223d2b7e24de804fc5112102d8ecede472a8dd3bcca48ec5d4e3d17192d7b1L22-R22) [[8]](diffhunk://#diff-0a72e336c6334619c7f95ed800fec95f9a3e69e665c62da1b4d770a1615ae4deL75-R75)

* Updated all usages of `carabiner-dev/actions/install/ampel`, `install/bnd`, `install/beaker`, `install/unpack`, and `install/policyctl` to version `v1.2.2` (`174f1c8`) in workflow steps. [[1]](diffhunk://#diff-31e56df38636909c37c0bf0d9489103529040c41124dd3fb4f0436577c869942L64-R68) [[2]](diffhunk://#diff-31e56df38636909c37c0bf0d9489103529040c41124dd3fb4f0436577c869942L133-R137) [[3]](diffhunk://#diff-d01b29015d6a13023338cdce7956d22428226eea86bec3d30cc81e24de5e65e7L28-R32) [[4]](diffhunk://#diff-53b0c6c4a0934513ef78191d1219fee860640a822819e77db7da2ff850b8c544L38-R44) [[5]](diffhunk://#diff-e5e544c465124a3e8a0dfb13197b522fe5d289867632850a7f2be765ecd4a9b5L63-R63)

* Updated all usages of `carabiner-dev/actions/go/versions` to version `v1.2.2` (`174f1c8`) in Go-related workflows. [[1]](diffhunk://#diff-a8080d767193adb8e3d77ec6eb45ac1b46cf48e9e9134ffcbcafb54f086188e1L21-R21) [[2]](diffhunk://#diff-8f30f5bab912fbb58c357ac9ea0f1ad77b8558ecc97843b08f9acc701444d64dL21-R21)

* Updated the verification step in `slsa/generate/action.yml` to use the new version of `carabiner-dev/actions/ampel/verify`.

**Consistency Improvements:**

* Ensured all reusable actions reference the same commit hash and version, reducing the risk of version drift and related issues. (All references above)

No other functional or logic changes were made; this is a straightforward dependency update across the repository.