### PR TITLE
Update ampel installer to v1.3.3

### DIFF
--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -15,7 +15,7 @@ inputs:
   version:
     description: 'AMPEL Version to Install'
     required: false
-    default: 'v1.3.2'
+    default: 'v1.3.3'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Bumps the default version of the ampel installer from v1.3.2 to v1.3.3.\n\nLatest release: https://github.com/carabiner-dev/ampel/releases/tag/v1.3.3\n\nSigned-off-by: Biner <biner@carabiner.dev>