### PR TITLE
Pin README action examples to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       id-token: write   # required to mint the workflow OIDC token
       contents: read
     steps:
-      - uses: carabiner-dev/actions/login@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1 # pin to a release commit once tagged
+      - uses: carabiner-dev/actions/login@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2 # pin to a release commit once tagged
       # CARABINER_CREDENTIALS is now set for subsequent steps
 ```
 
@@ -64,7 +64,7 @@ its attestations against a policy.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     policy: 'path/to/policy.yaml'   # URI or path to policy code
     subject: 'path/to/artifact'     # or digest, eg sha256:98349875bf3e09...
@@ -93,7 +93,7 @@ its attestations against a policy.
 **Basic verification:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/binary'
@@ -103,7 +103,7 @@ its attestations against a policy.
 **Verification with custom attestations:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     policy: '.ampel/policy.yaml'
     subject: 'sha256:abc123...'
@@ -115,7 +115,7 @@ its attestations against a policy.
 **Verification with attestation push:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -128,7 +128,7 @@ its attestations against a policy.
 **Verification without failing the workflow:**
 
 ```yaml
-- uses: carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     policy: '.ampel/policy.yaml'
     subject: 'path/to/artifact'
@@ -146,7 +146,7 @@ codebase IDs.
 #### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     ecosystems: |
       golang

--- a/go/README.md
+++ b/go/README.md
@@ -32,7 +32,7 @@ used internally by `go/check-latest` and `go/check-previous`.
 ```yaml
 - name: Resolve Go versions
   id: go-versions
-  uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 
 - name: Set up Go
   uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -55,13 +55,13 @@ doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/go/check-latest@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 With a custom go.mod path:
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-latest@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/go/check-latest@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     go-mod-path: 'src/go.mod'
 ```
@@ -89,7 +89,7 @@ error message if the version doesn't match.
 ### Usage
 
 ```yaml
-- uses: carabiner-dev/actions/go/check-previous@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/go/check-previous@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 On failure, the action produces an error like:
@@ -118,13 +118,13 @@ Go is already installed on the runner (e.g. via `actions/setup-go`).
   with:
     go-version-file: 'go.mod'
 
-- uses: carabiner-dev/actions/go/modtidy@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/go/modtidy@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 With a custom working directory:
 
 ```yaml
-- uses: carabiner-dev/actions/go/modtidy@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/go/modtidy@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
   with:
     working-directory: 'src'
 ```
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - id: go-versions
-        uses: carabiner-dev/actions/go/versions@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+        uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
       - id: matrix
         run: |
           echo "go-versions=[\"${{ steps.go-versions.outputs.GO_VERSION_STABLE }}\",\"${{ steps.go-versions.outputs.GO_VERSION_PREVIOUS }}\"]" >> "$GITHUB_OUTPUT"

--- a/login/README.md
+++ b/login/README.md
@@ -112,7 +112,7 @@ jobs:
       id-token: write   # required to mint the workflow OIDC token
       contents: read
     steps:
-      - uses: carabiner-dev/actions/login@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1 # pin to a release commit once tagged
+      - uses: carabiner-dev/actions/login@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2 # pin to a release commit once tagged
 
       # Subsequent steps can read CARABINER_CREDENTIALS from the environment.
       - run: echo "token expires in ${{ steps.login.outputs.expires-in }}s"

--- a/slsa/generate/README.md
+++ b/slsa/generate/README.md
@@ -57,7 +57,7 @@ jobs:
       contents: read
       actions: read      # Read run metadata and artifacts
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      - uses: carabiner-dev/actions/slsa/generate@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 ### Watch specific jobs
@@ -83,7 +83,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      - uses: carabiner-dev/actions/slsa/generate@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
         with:
           watch-jobs: "build, integration-tests"
 ```
@@ -98,7 +98,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: carabiner-dev/actions/slsa/generate@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+      - uses: carabiner-dev/actions/slsa/generate@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
         with:
           artifacts: "oci://ghcr.io/my-org/my-image"
           dependencies: "git+https://github.com/my-org/my-lib@abc123def"

--- a/unpack/sbom/README.md
+++ b/unpack/sbom/README.md
@@ -10,7 +10,7 @@ format.
 ## Usage
 
 ```yaml
-- uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+- uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 That's it. With no inputs, the action will:
@@ -73,7 +73,7 @@ When the CycloneDX format is used, the extension is `.cdx.json` instead of `.spd
 ```yaml
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
 ```
 
 ### Generate only for Go and npm ecosystems
@@ -81,7 +81,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     with:
       ecosystems: |
         golang
@@ -93,7 +93,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     with:
       codebases: |
         golang:.
@@ -105,7 +105,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     with:
       format: cyclonedx
       files: 'true'
@@ -117,7 +117,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     with:
       ignore: |
         vendor
@@ -130,7 +130,7 @@ steps:
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     with:
       output-path: /tmp
       push-to-release: ${{ steps.tag.outputs.tag_name }}
@@ -144,7 +144,7 @@ steps:
 steps:
   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-  - uses: carabiner-dev/actions/unpack/sbom@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+  - uses: carabiner-dev/actions/unpack/sbom@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
     id: sbom
     with:
       output-path: sboms/


### PR DESCRIPTION
Updates `uses:` references in README YAML code examples to point to the latest release commit SHAs.

| Repository | Version | Commit |
|---|---|---|
| `actions/checkout` | `v7.0.0` | `9c091bb21b7c` |
| `actions/setup-go` | `v7.0.0` | `b7ad1dad31e0` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93` |
| `carabiner-dev/actions` | `v1.2.2` | `174f1c83779a` |

Signed-off-by: Biner[Bot] <biner@carabiner.dev>