### PR TITLE
Pin internal action refs to 619a474b2178

### DIFF
--- a/ampel/verify/action.yml
+++ b/ampel/verify/action.yml
@@ -71,10 +71,10 @@ runs:
     # the automation bump workflow maintains) instead of duplicating it here.
     - if: ${{ inputs.ampel-version == '' }}
       name: 🔴🟡🟢 AMPEL Setup
-      uses: carabiner-dev/actions/install/ampel@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/install/ampel@619a474b2178d06ccf274349397cd67a7802a4fe
     - if: ${{ inputs.ampel-version != '' }}
       name: 🔴🟡🟢 AMPEL Setup (pinned)
-      uses: carabiner-dev/actions/install/ampel@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/install/ampel@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         version: ${{ inputs.ampel-version }}
 
@@ -143,7 +143,7 @@ runs:
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' }}
       name: Setup bnd
-      uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/install/bnd@619a474b2178d06ccf274349397cd67a7802a4fe
 
     - if: ${{ steps.attest-check.outputs.attest == 'true' }}
       name: sign-ampel-results

--- a/beaker/tests/action.yml
+++ b/beaker/tests/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/beaker@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/beaker@619a474b2178d06ccf274349397cd67a7802a4fe
       name: Beaker Setup
       id: install
 
-    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/bnd@619a474b2178d06ccf274349397cd67a7802a4fe
       name: bnd Setup
       id: install-bnd
 

--- a/bnd/sign/action.yml
+++ b/bnd/sign/action.yml
@@ -35,13 +35,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/bnd@619a474b2178d06ccf274349397cd67a7802a4fe
       name: Install bnd
       with:
         version: ${{ inputs.bnd-version }}
       if: ${{ inputs.bnd-version != '' }}
 
-    - uses: carabiner-dev/actions/install/bnd@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/bnd@619a474b2178d06ccf274349397cd67a7802a4fe
       name: Install bnd (latest)
       if: ${{ inputs.bnd-version == '' }}
 

--- a/go/check-latest/action.yml
+++ b/go/check-latest/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/go/versions@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/go/check-previous/action.yml
+++ b/go/check-previous/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/go/versions@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: ampel
         version: ${{ inputs.version }}

--- a/install/beaker/action.yml
+++ b/install/beaker/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::error::beaker does not have a Windows binary"
         exit 1
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: beaker
         version: ${{ inputs.version }}

--- a/install/bnd/action.yml
+++ b/install/bnd/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: bnd
         version: ${{ inputs.version }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -72,7 +72,7 @@ runs:
 
       - name: Bootstrap trusted ampel
         if: inputs.verify == 'true'
-        uses: carabiner-dev/actions/install/ampel-bootstrap@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+        uses: carabiner-dev/actions/install/ampel-bootstrap@619a474b2178d06ccf274349397cd67a7802a4fe
         id: bootstrap
 
       - name: Detect platform

--- a/install/policyctl/action.yml
+++ b/install/policyctl/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: policyctl
         version: ${{ inputs.version }}

--- a/install/revex/action.yml
+++ b/install/revex/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: revex
         version: ${{ inputs.version }}

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: snappy
         version: ${{ inputs.version }}

--- a/install/unpack/action.yml
+++ b/install/unpack/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         tool: unpack
         version: ${{ inputs.version }}

--- a/slsa/generate/action.yml
+++ b/slsa/generate/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Verify tejolote provenance
       if: inputs.verify == 'true'
-      uses: carabiner-dev/actions/ampel/verify@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/ampel/verify@619a474b2178d06ccf274349397cd67a7802a4fe
       with:
         subject: ${{ steps.install-tejolote.outputs.bin }}
         collector: "fs:${{ steps.install-tejolote.outputs.attest-dir }}"

--- a/unpack/sbom/action.yml
+++ b/unpack/sbom/action.yml
@@ -60,7 +60,7 @@ runs:
   using: "composite"
   steps:
     - name: Install unpack
-      uses: carabiner-dev/actions/install/unpack@174f1c83779af3d3d7e451b7ead7ba824d0d2aa9 # v1.2.2
+      uses: carabiner-dev/actions/install/unpack@619a474b2178d06ccf274349397cd67a7802a4fe
 
     - name: Generate SBOMs
       id: generate


### PR DESCRIPTION
Pins every `carabiner-dev/actions` self-reference in the composite actions to the current tip of main (`619a474b2178d06ccf274349397cd67a7802a4fe`), so the next release tag carries internal pins pointing at its own content rather than the previous release. Run before cutting a release.

Signed-off-by: Biner <biner@carabiner.dev>