### PR TITLE
Update bnd installer to v0.4.4

### DIFF
--- a/install/bnd/action.yml
+++ b/install/bnd/action.yml
@@ -15,7 +15,7 @@ inputs:
   version:
     description: 'bnd version to install'
     required: false
-    default: 'v0.4.2'
+    default: 'v0.4.4'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Bumps the default version of the bnd installer from v0.4.2 to v0.4.4.\n\nLatest release: https://github.com/carabiner-dev/bnd/releases/tag/v0.4.4\n\nSigned-off-by: Biner <biner@carabiner.dev>