### PR TITLE
Ignore internal action pins in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      # Self-references are sha-pinned to the release commit and bumped
+      # just-in-time by the pin-internal-refs automation; tracking them here
+      # opens one PR per directory on every push to main.
+      - dependency-name: "carabiner-dev/actions/*"
     groups:
       actions:
         update-types:


### PR DESCRIPTION
This pull request makes a small configuration update to the `.github/dependabot.yaml` file to improve Dependabot behavior.

* Dependabot configuration:
  * Added an `ignore` rule for dependencies matching `carabiner-dev/actions/*` to prevent unnecessary pull requests for internal action references that are already managed by automation.