### PR TITLE
Migrate vexflow to use install-and-verify

### DIFF
--- a/install/vexflow/action.yaml
+++ b/install/vexflow/action.yaml
@@ -1,13 +1,9 @@
 # SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-# [!] Build notice:
-# Note that this installer downloads and builds vexflow at head. This
-# will replaced with a verified installer soon.
-
-name: setup revex
+name: setup vexflow
 author: carabiner-dev
-description: 'Installs the Vexflow binary into the runner'
+description: 'Installs the Vexflow VEX lifecycle manager into the runner environment'
 branding:
   icon: 'download-cloud'
   color: 'green'
@@ -16,61 +12,16 @@ inputs:
     description: 'Path to install the binary'
     required: false
     default: '$HOME/.carabiner'
+  version:
+    description: 'Vexflow version to install'
+    required: false
+    default: 'v0.0.1-pre3'
 runs:
   using: "composite"
   steps:
-      - name: Validate install-dir
-        shell: bash
-        run: |
-          case "$INPUTS_INSTALL_DIR" in
-            ''|*[!A-Za-z0-9._/\$~-]*)
-              echo "::error::install-dir must be non-empty and contain only [A-Za-z0-9._/\$~-]; got: $INPUTS_INSTALL_DIR"
-              exit 1
-              ;;
-          esac
-        env:
-          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
-
-      # - name: Checkout code
-      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      #   with:
-      #     persist-credentials: false
-      #     repository: carabiner-dev/revex
-      #     path: '.build/revex/'
-      #     ref: main
-
-      # - name: Set up Go
-      #   uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      #   with:
-      #     go-version-file: '.build/revex/go.mod'
-      #     cache: false
-      #     check-latest: true
-
-      # - name: Build
-      #   shell: bash
-      #   run: |
-      #     mkdir -p ${{ inputs.install-dir }}/bin || :
-      #     cd .build/revex && go build -o ${{ inputs.install-dir }}/bin/revex .
-      #     cd - 
-      #     rm -rf .build/revex
-      - name: Build
-        shell: bash
-        run: |
-          mkdir -p ${INPUTS_INSTALL_DIR}/bin || :
-          curl -Lo ${INPUTS_INSTALL_DIR}/bin/vexflow https://github.com/carabiner-dev/vexflow/releases/download/v0.0.1-pre3/vexflow-v0.0.1-pre3-linux-amd64
-          chmod 0755 ${INPUTS_INSTALL_DIR}/bin/vexflow
-        env:
-          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
-      - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH # zizmor: ignore[github-env] install-dir validated upstream
-        shell: bash
-        env:
-          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
-      - if: ${{ runner.os == 'Windows' }}
-        run: echo "${INPUTS_INSTALL_DIR}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append # zizmor: ignore[github-env] install-dir validated upstream
-        shell: bash
-        env:
-          INPUTS_INSTALL_DIR: ${{ inputs.install-dir }}
-      
-      - shell: bash
-        run: vexflow --help
+    - uses: carabiner-dev/actions/install/download-and-verify@619a474b2178d06ccf274349397cd67a7802a4fe
+      with:
+        tool: vexflow
+        version: ${{ inputs.version }}
+        install-dir: ${{ inputs.install-dir }}
+        attestation-file: vexflow-${{ inputs.version }}.provenance.json


### PR DESCRIPTION
This pull request updates the `install/vexflow/action.yaml` installer to improve how the Vexflow binary is installed and to clarify the action's metadata. The installer now uses a verified download-and-verify step, adds support for specifying the Vexflow version, and updates the action's name and description for accuracy.

**Installer improvements:**

* Replaces the manual build and download logic with a call to the shared `download-and-verify` action, ensuring the Vexflow binary is downloaded securely with provenance attestation.
* Adds a new `version` input to allow users to specify which Vexflow version to install.

**Metadata and documentation updates:**

* Updates the action's name from `setup revex` to `setup vexflow` and clarifies the description to indicate it installs the Vexflow VEX lifecycle manager.
