### PR TITLE
Pin internal action refs to 2fec8bd8e1dc

### DIFF
--- a/ampel/verify/action.yml
+++ b/ampel/verify/action.yml
@@ -80,10 +80,10 @@ runs:
     # the automation bump workflow maintains) instead of duplicating it here.
     - if: ${{ inputs.ampel-version == '' }}
       name: 🔴🟡🟢 AMPEL Setup
-      uses: carabiner-dev/actions/install/ampel@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/install/ampel@2fec8bd8e1dcfdea26080648070b4827f1fa0584
     - if: ${{ inputs.ampel-version != '' }}
       name: 🔴🟡🟢 AMPEL Setup (pinned)
-      uses: carabiner-dev/actions/install/ampel@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/install/ampel@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         version: ${{ inputs.ampel-version }}
 

--- a/beaker/tests/action.yml
+++ b/beaker/tests/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/beaker@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/beaker@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       name: Beaker Setup
       id: install
 
-    - uses: carabiner-dev/actions/install/bnd@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/bnd@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       name: bnd Setup
       id: install-bnd
 

--- a/bnd/sign/action.yml
+++ b/bnd/sign/action.yml
@@ -35,13 +35,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: carabiner-dev/actions/install/bnd@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/bnd@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       name: Install bnd
       with:
         version: ${{ inputs.bnd-version }}
       if: ${{ inputs.bnd-version != '' }}
 
-    - uses: carabiner-dev/actions/install/bnd@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/bnd@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       name: Install bnd (latest)
       if: ${{ inputs.bnd-version == '' }}
 

--- a/go/check-latest/action.yml
+++ b/go/check-latest/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/go/versions@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/go/check-previous/action.yml
+++ b/go/check-previous/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Resolve Go versions
       id: versions
-      uses: carabiner-dev/actions/go/versions@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/go/versions@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         go-mod-path: ${{ inputs.go-mod-path }}
 

--- a/install/ampel/action.yml
+++ b/install/ampel/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: ampel
         version: ${{ inputs.version }}

--- a/install/beaker/action.yml
+++ b/install/beaker/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "::error::beaker does not have a Windows binary"
         exit 1
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: beaker
         version: ${{ inputs.version }}

--- a/install/bnd/action.yml
+++ b/install/bnd/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: bnd
         version: ${{ inputs.version }}

--- a/install/download-and-verify/action.yml
+++ b/install/download-and-verify/action.yml
@@ -81,7 +81,7 @@ runs:
 
       - name: Bootstrap trusted ampel
         if: inputs.verify == 'true'
-        uses: carabiner-dev/actions/install/ampel-bootstrap@16009dca48ac369882d4333f1d15d7cd3a4ded31
+        uses: carabiner-dev/actions/install/ampel-bootstrap@2fec8bd8e1dcfdea26080648070b4827f1fa0584
         id: bootstrap
 
       - name: Detect platform

--- a/install/policyctl/action.yml
+++ b/install/policyctl/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: policyctl
         version: ${{ inputs.version }}

--- a/install/revex/action.yml
+++ b/install/revex/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: revex
         version: ${{ inputs.version }}

--- a/install/snappy/action.yml
+++ b/install/snappy/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: snappy
         version: ${{ inputs.version }}

--- a/install/unpack/action.yml
+++ b/install/unpack/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: unpack
         version: ${{ inputs.version }}

--- a/install/vexflow/action.yaml
+++ b/install/vexflow/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+    - uses: carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         tool: vexflow
         version: ${{ inputs.version }}

--- a/slsa/generate/action.yml
+++ b/slsa/generate/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Verify tejolote provenance
       if: inputs.verify == 'true'
-      uses: carabiner-dev/actions/ampel/verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/ampel/verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
       with:
         subject: ${{ steps.install-tejolote.outputs.bin }}
         collector: "fs:${{ steps.install-tejolote.outputs.attest-dir }}"

--- a/unpack/sbom/action.yml
+++ b/unpack/sbom/action.yml
@@ -60,7 +60,7 @@ runs:
   using: "composite"
   steps:
     - name: Install unpack
-      uses: carabiner-dev/actions/install/unpack@16009dca48ac369882d4333f1d15d7cd3a4ded31
+      uses: carabiner-dev/actions/install/unpack@2fec8bd8e1dcfdea26080648070b4827f1fa0584
 
     - name: Generate SBOMs
       id: generate


### PR DESCRIPTION
Pins every `carabiner-dev/actions` self-reference in the composite actions to the current tip of main (`2fec8bd8e1dcfdea26080648070b4827f1fa0584`), so the next release tag carries internal pins pointing at its own content rather than the previous release. Run before cutting a release.

Signed-off-by: Biner <biner@carabiner.dev>